### PR TITLE
Fixed BEGINSWITH query

### DIFF
--- a/Kinvey/Carthage/Checkouts/NSPredicate-MongoDB-Adaptor/MongoDBPredicateAdaptor.m
+++ b/Kinvey/Carthage/Checkouts/NSPredicate-MongoDB-Adaptor/MongoDBPredicateAdaptor.m
@@ -262,7 +262,7 @@ NSString *const jsEqualsOperator = @"===";
     NSPredicate *newPredicate = nil;
     id constant = predicate.rightExpression.constantValue;
     if (constant) {
-        NSString *beginsWithRegex = [NSString stringWithFormat:@"/^%@/",predicate.rightExpression.constantValue];
+        NSString *beginsWithRegex = [NSString stringWithFormat:@"^%@",predicate.rightExpression.constantValue];
         newPredicate = [MongoDBPredicateAdaptor replacementPredicateForPredicate:predicate withRegexString:beginsWithRegex];
     }
     return newPredicate;
@@ -272,7 +272,7 @@ NSString *const jsEqualsOperator = @"===";
     NSPredicate *newPredicate = nil;
     id constant = predicate.rightExpression.constantValue;
     if (constant) {
-        NSString *endsWithRegex = [NSString stringWithFormat:@"/.*%@/",predicate.rightExpression.constantValue];
+        NSString *endsWithRegex = [NSString stringWithFormat:@".*%@",predicate.rightExpression.constantValue];
         newPredicate = [MongoDBPredicateAdaptor replacementPredicateForPredicate:predicate withRegexString:endsWithRegex];
     }
     return newPredicate;
@@ -282,7 +282,7 @@ NSString *const jsEqualsOperator = @"===";
     NSPredicate *newPredicate = nil;
     id constant = predicate.rightExpression.constantValue;
     if (constant) {
-        NSString *containsRegex = [NSString stringWithFormat:@"/.*%@.*/",predicate.rightExpression.constantValue];
+        NSString *containsRegex = [NSString stringWithFormat:@".*%@.*",predicate.rightExpression.constantValue];
         newPredicate = [MongoDBPredicateAdaptor replacementPredicateForPredicate:predicate withRegexString:containsRegex];
     }
     return newPredicate;

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -67,6 +67,11 @@ class QueryTest: XCTestCase {
     func testQueryRegex() {
         XCTAssertEqual(encodeQuery(Query(format: "name MATCHES %@", "acme.*corp")), "query=\(encodeURL(["name" : ["$regex" : "acme.*corp"]]))")
     }
+
+    func testQueryBeginsWith() {
+        XCTAssertEqual(encodeQuery(Query(format: "name BEGINSWITH %@", "acme")), encodeURL(["name" : ["$regex" : "^acme"]]))
+    }
+
     
     func testQueryGeoWithinCenterSphere() {
         let resultString = encodeQuery(Query(format: "location = %@", MKCircle(centerCoordinate: CLLocationCoordinate2D(latitude: 40.74, longitude: -74), radius: 10000)))


### PR DESCRIPTION
Issue from support - 

``````
The following query fails - 

let predicate = NSPredicate(format: "email beginswith %@", "t")
        let query = Query(predicate: predicate)
        store.pull(query) { (partners, error)```

with the error  -

{"error":"DisallowedQuerySyntax","description":"Your query included syntax that is not supported. Please refer to the debug property or contact support for more information.","debug":"Regular expression in queries must be anchored at the beginning (they must start with ^)"}

``````

Fixed a bug in the Mongo Query adaptor that puts additional / on both sides of an anchor regex.
