### PR TITLE
MLIBZ-1809: unregister push token crash

### DIFF
--- a/Kinvey/KinveyTests/PushTestCase.swift
+++ b/Kinvey/KinveyTests/PushTestCase.swift
@@ -77,6 +77,24 @@ class PushTestCase: KinveyTestCase {
         }
     }
     
+    func testUnregisterDeviceToken() {
+        let client = Client(appKey: "_appKey_", appSecret: "_appSecret_")
+        
+        weak var expectaionUnRegister = expectation(description: "UnRegister")
+        
+        client.push.unRegisterDeviceToken { (success, error) in
+            XCTAssertFalse(success)
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.localizedDescription, "Device token not found")
+            
+            expectaionUnRegister?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectaionUnRegister = nil
+        }
+    }
+    
     func testBadgeNumber() {
         UIApplication.shared.applicationIconBadgeNumber = 1
         


### PR DESCRIPTION
#### Description

Returning an error through completion handler instead of crash

#### Changes

* Push class in order to not crash
* Overload the unregister method to complain with the `Result<Success, Failure>` pattern

#### Tests

* Add a new unit test to cover the use case
