### PR TITLE
MLIBZ-1927: query with plus sign

### DIFF
--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -358,6 +358,16 @@ internal class HttpRequest: TaskProgressRequest, Request {
         if let clientAppVersion = client.clientAppVersion {
             request.setValue(clientAppVersion, forHTTPHeaderField: KinveyHeaderField.clientAppVersion)
         }
+        if let url = request.url,
+            let query = url.query,
+            query.contains("+"),
+            let decodedQuery = query.removingPercentEncoding,
+            let newQuery = decodedQuery.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+"))),
+            var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        {
+            urlComponents.percentEncodedQuery = newQuery
+            request.url = urlComponents.url
+        }
     }
     
     func execute(urlSession: URLSession? = nil, _ completionHandler: DataResponseCompletionHandler? = nil) {

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -1212,6 +1212,91 @@ class NetworkStoreTests: StoreTestCase {
         }
     }
     
+    func testPlusSign() {
+        let person = Person()
+        person.name = "C++"
+        
+        var mockJson: JsonDictionary?
+        do {
+            if useMockData {
+                let personId = UUID().uuidString
+                mockResponse { (request) -> HttpResponse in
+                    var json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
+                    json[PersistableIdKey] = personId
+                    mockJson = json
+                    return HttpResponse(json: json)
+                }
+            }
+            defer {
+                if useMockData {
+                    setURLProtocol(nil)
+                }
+            }
+            
+            weak var expectationSave = expectation(description: "Save")
+            
+            store.save(person, writePolicy: .forceNetwork) { person, error in
+                XCTAssertNotNil(person)
+                XCTAssertNil(error)
+                
+                if let person = person {
+                    XCTAssertNotNil(person.name)
+                    if let name = person.name {
+                        XCTAssertEqual(name, "C++")
+                    }
+                }
+                
+                expectationSave?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationSave = nil
+            }
+        }
+        
+        XCTAssertNotNil(person.personId)
+        guard let personId = person.personId else {
+            return
+        }
+        
+        do {
+            if useMockData {
+                mockResponse(json: [mockJson!])
+            }
+            defer {
+                if useMockData {
+                    setURLProtocol(nil)
+                }
+            }
+            
+            let query = Query(format: "name == %@", "C++")
+            
+            weak var expectationFind = expectation(description: "Find")
+            
+            store.find(query, readPolicy: .forceNetwork) { persons, error in
+                XCTAssertNotNil(persons)
+                XCTAssertNil(error)
+                
+                if let persons = persons {
+                    XCTAssertGreaterThan(persons.count, 0)
+                    XCTAssertNotNil(persons.first)
+                    if let person = persons.first {
+                        XCTAssertNotNil(person.name)
+                        if let name = person.name {
+                            XCTAssertEqual(name, "C++")
+                        }
+                    }
+                }
+                
+                expectationFind?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationFind = nil
+            }
+        }
+    }
+    
     func testGeolocationQuery() {
         let person = Person()
         person.name = "Victor Barros"

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -292,6 +292,15 @@ class QueryTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
     
+    func testPredicatePlusSign() {
+        let result = encodeQuery(Query(format: "language == %@", "C++"))
+        let json = [
+            "language" : "C++"
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
     func testArrayContains() {
         let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
         let predicate = cache.translate(predicate: NSPredicate(format: "authorNames contains %@", "Victor"))


### PR DESCRIPTION
#### Description

Encoding "+" inside URL queries

#### Changes

* Workaround since `URLQueryItem` does not encode "+" in URL queries

#### Tests

* Unit test that saves and then try to retrieve by query a string value that contains a plug sign, like "C++" for example
