### PR TITLE
MLIBZ-1936: removing support for tvOS for now

### DIFF
--- a/Kinvey.podspec
+++ b/Kinvey.podspec
@@ -70,7 +70,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.12"
   s.watchos.deployment_target = "2.2"
-  s.tvos.deployment_target = "9.2"
+  # s.tvos.deployment_target = "9.2"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
#### Description
Removing support for tvOS for now since seems to be a problem with PubNub + tvOS + CocoaPods

#### Changes
* Removing support for tvOS for now

#### Tests
* Tested manually
