### PR TITLE
MLIBZ-1951: crashing with empty body error

### DIFF
--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -179,16 +179,46 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
         return unknownJsonError(httpResponse: httpResponse, data: data, json: json)
     }
     
-    static func buildDataLinkEntityNotFound(httpResponse: HTTPURLResponse?, data: Data?, json: [String : String]) -> Error {
-        return dataLinkEntityNotFound(httpResponse: httpResponse, data: data, debug: json["debug"]!, description: json["description"]!)
+    static func buildDataLinkEntityNotFound(
+        httpResponse: HTTPURLResponse?,
+        data: Data?,
+        debug: String,
+        description: String
+    ) -> Error {
+        return dataLinkEntityNotFound(
+            httpResponse: httpResponse,
+            data: data,
+            debug: debug,
+            description: description
+        )
     }
     
-    static func buildMethodNotAllowed(httpResponse: HTTPURLResponse?, data: Data?, json: [String : String]) -> Error {
-        return methodNotAllowed(httpResponse: httpResponse, data: data, debug: json["debug"]!, description: json["description"]!)
+    static func buildMethodNotAllowed(
+        httpResponse: HTTPURLResponse?,
+        data: Data?,
+        debug: String,
+        description: String
+    ) -> Error {
+        return methodNotAllowed(
+            httpResponse: httpResponse,
+            data: data,
+            debug: debug,
+            description: description
+        )
     }
     
-    static func buildUnauthorized(httpResponse: HTTPURLResponse?, data: Data?, json: [String : String]) -> Error {
-        return unauthorized(httpResponse: httpResponse, data: data, error: json["error"]!, description: json["description"]!)
+    static func buildUnauthorized(
+        httpResponse: HTTPURLResponse?,
+        data: Data?,
+        error: String,
+        description: String
+    ) -> Error {
+        return unauthorized(
+            httpResponse: httpResponse,
+            data: data,
+            error: error,
+            description: description
+        )
     }
     
 }

--- a/Kinvey/Kinvey/PushOperation.swift
+++ b/Kinvey/Kinvey/PushOperation.swift
@@ -114,9 +114,16 @@ internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, [Swift.Erro
                             }
                         } else if let response = response, response.isUnauthorized,
                             let data = data,
-                            let json = self.client.responseParser.parse(data) as? [String : String]
+                            let json = self.client.responseParser.parse(data) as? [String : String],
+                            let error = json["error"],
+                            let description = json["description"]
                         {
-                            let error = Error.buildUnauthorized(httpResponse: response.httpResponse, data: data, json: json)
+                            let error = Error.buildUnauthorized(
+                                httpResponse: response.httpResponse,
+                                data: data,
+                                error: error,
+                                description: description
+                            )
                             switch error {
                             case .unauthorized(_, _, let error, _):
                                 if error == Error.InsufficientCredentials {

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -712,6 +712,41 @@ class SyncStoreTests: StoreTestCase {
         XCTAssertEqual(store.syncCount(), 0)
     }
     
+    func testPushError401EmptyBody() {
+        save()
+        
+        defer {
+            store.clearCache()
+            
+            XCTAssertEqual(store.syncCount(), 0)
+        }
+        
+        XCTAssertEqual(store.syncCount(), 1)
+        
+        if useMockData {
+            mockResponse(statusCode: 401, json: [:])
+        }
+        defer {
+            if useMockData { setURLProtocol(nil) }
+        }
+        
+        weak var expectationPush = expectation(description: "Push")
+        
+        store.push() { count, error in
+            self.assertThread()
+            XCTAssertNil(count)
+            XCTAssertNotNil(error)
+            
+            expectationPush?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationPush = nil
+        }
+        
+        XCTAssertEqual(store.syncCount(), 1)
+    }
+    
     func testPushInvalidDataStoreType() {
         save()
         


### PR DESCRIPTION
#### Description

Crash was happening when a DLC/BL is returning an empty body error

#### Changes

* Avoiding force unwrap optionals when building error objects

#### Tests

* No need for additional unit test
