### PR TITLE
MLIBZ-1970: bug fix for count not translating queries

### DIFF
--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -329,7 +329,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     @discardableResult
     open func count(_ query: Query? = nil, readPolicy: ReadPolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
-        let operation = CountOperation<T>(query: query, readPolicy: readPolicy, cache: cache, client: client)
+        let operation = CountOperation<T>(query: Query(query: query ?? Query(), persistableType: T.self), readPolicy: readPolicy, cache: cache, client: client)
         let request = operation.execute { result in
             DispatchQueue.main.async {
                 completionHandler?(result)


### PR DESCRIPTION
#### Description

Queries must be translated if the property has an alias name
Bug detected during random look at the code

#### Changes

* Fix for count() method

#### Tests

* New unit test to cover the use case
