### PR TITLE
MLIBZ-2046: cascade delete

### DIFF
--- a/Kinvey/Kinvey/ObjCRuntime.swift
+++ b/Kinvey/Kinvey/ObjCRuntime.swift
@@ -28,7 +28,8 @@ internal class ObjCRuntime: NSObject {
         let property = class_getProperty(cls, propertyName)
         let attributeValueCString = property_copyAttributeValue(property, "T")
         defer { free(attributeValueCString) }
-        if let attributeValue = String(validatingUTF8: attributeValueCString!),
+        if let attributeValueCString = attributeValueCString,
+            let attributeValue = String(validatingUTF8: attributeValueCString),
             let textCheckingResult = regexClassName.matches(in: attributeValue, range: NSMakeRange(0, attributeValue.characters.count)).first
         {
             let attributeValueNSString = attributeValue as NSString

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -191,14 +191,11 @@ class ListValueTransform<T: RealmSwift.Object>: TransformOf<List<T>, [JsonDictio
 
 /// Overload operator for `List` values
 public func <-<T: BaseMappable>(lhs: List<T>, rhs: (String, Map)) {
-    let (_, map) = rhs
+    let (right, map) = rhs
     var list = lhs
-    switch map.mappingType {
-    case .fromJSON:
-        list <- (map, ListValueTransform<T>(list))
-    case .toJSON:
-        list <- (map, ListValueTransform<T>(list))
-    }
+    let transform = ListValueTransform<T>(list)
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
+    list <- (map, transform)
 }
 
 // MARK: String Value Transform
@@ -226,13 +223,14 @@ class StringValueTransform: TransformOf<List<StringValue>, [String]> {
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<StringValue>, right: (String, Map)) {
     let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
+    let transform = StringValueTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
     var list = left
     switch map.mappingType {
     case .toJSON:
-        list <- (map, StringValueTransform())
+        list <- (map, transform)
     case .fromJSON:
-        list <- (map, StringValueTransform())
+        list <- (map, transform)
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -263,13 +261,14 @@ class IntValueTransform: TransformOf<List<IntValue>, [Int]> {
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<IntValue>, right: (String, Map)) {
     let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
+    let transform = IntValueTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
     var list = left
     switch map.mappingType {
     case .toJSON:
-        list <- (map, IntValueTransform())
+        list <- (map, transform)
     case .fromJSON:
-        list <- (map, IntValueTransform())
+        list <- (map, transform)
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -306,13 +305,14 @@ class FloatValueTransform: TransformOf<List<FloatValue>, [Float]> {
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<FloatValue>, right: (String, Map)) {
     let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
+    let transform = FloatValueTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
     var list = left
     switch map.mappingType {
     case .toJSON:
-        list <- (map, FloatValueTransform())
+        list <- (map, transform)
     case .fromJSON:
-        list <- (map, FloatValueTransform())
+        list <- (map, transform)
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -343,13 +343,14 @@ class DoubleValueTransform: TransformOf<List<DoubleValue>, [Double]> {
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<DoubleValue>, right: (String, Map)) {
     let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
+    let transform = DoubleValueTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
     var list = left
     switch map.mappingType {
     case .toJSON:
-        list <- (map, DoubleValueTransform())
+        list <- (map, transform)
     case .fromJSON:
-        list <- (map, DoubleValueTransform())
+        list <- (map, transform)
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -380,13 +381,14 @@ class BoolValueTransform: TransformOf<List<BoolValue>, [Bool]> {
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<BoolValue>, right: (String, Map)) {
     let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
+    let transform = BoolValueTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
     var list = left
     switch map.mappingType {
     case .toJSON:
-        list <- (map, BoolValueTransform())
+        list <- (map, transform)
     case .fromJSON:
-        list <- (map, BoolValueTransform())
+        list <- (map, transform)
         left.removeAll()
         left.append(objectsIn: list)
     }

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -513,6 +513,7 @@ extension RealmCache: DynamicCacheType {
                     if let transform = transform,
                         let value = transform.transformFromJSON(entity[key]) as? NSObject,
                         let property = properties[translatedKey],
+                        property.type != .array,
                         let objectClassName = property.objectClassName,
                         let schema = realm.schema[objectClassName]
                     {

--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import Kinvey
+import RealmSwift
 
 class CacheStoreTests: StoreTestCase {
     
@@ -272,6 +273,14 @@ class CacheStoreTests: StoreTestCase {
         book.title = "Swift for the win!"
         book.authorNames.append("Victor Barros")
         
+        let book1stEdition = BookEdition()
+        book1stEdition.year = 2017
+        book.editions.append(book1stEdition)
+        
+        let book2ndEdition = BookEdition()
+        book2ndEdition.year = 2016
+        book.editions.append(book2ndEdition)
+        
         if useMockData {
             var mockJson: JsonDictionary? = nil
             var count = 0
@@ -368,6 +377,17 @@ class CacheStoreTests: StoreTestCase {
                 expectationFindLocal = nil
                 expectationFindNetwork = nil
             }
+        }
+        
+        do {
+            let basePath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+            var url = URL(fileURLWithPath: basePath)
+            url = url.appendingPathComponent(sharedClient.appKey!)
+            url = url.appendingPathComponent("kinvey.realm")
+            let realm = try! Realm(fileURL: url)
+            XCTAssertEqual(realm.objects(Acl.self).count, 1)
+            XCTAssertEqual(realm.objects(StringValue.self).count, 1)
+            XCTAssertEqual(realm.objects(BookEdition.self).count, 2)
         }
     }
     

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -247,6 +247,7 @@ class DataTypeTestCase: StoreTestCase {
                 XCTFail()
             }
         }
+        
         XCTAssertTrue(entityId)
         XCTAssertTrue(metadata)
         XCTAssertTrue(acl)

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -199,6 +199,66 @@ class DataTypeTestCase: StoreTestCase {
         XCTAssertEqual(transform.transformToJSON(Date(timeIntervalSince1970: 1479114355.787)), "2016-11-14T09:05:55.787Z")
     }
     
+    func testPropertyMapping() {
+        let propertyMapping = Book.propertyMapping()
+        var entityId = false,
+        metadata = false,
+        acl = false,
+        title = false,
+        authorNames = false,
+        editions = false,
+        editionsYear = false,
+        editionsRetailPrice = false,
+        editionsRating = false,
+        editionsAvailable = false
+        for (left, (right, _)) in propertyMapping {
+            switch left {
+            case "entityId":
+                XCTAssertEqual(right, "_id")
+                entityId = true
+            case "metadata":
+                XCTAssertEqual(right, "_kmd")
+                metadata = true
+            case "acl":
+                XCTAssertEqual(right, "_acl")
+                acl = true
+            case "title":
+                XCTAssertEqual(right, "title")
+                title = true
+            case "authorNames":
+                XCTAssertEqual(right, "authorNames")
+                authorNames = true
+            case "editions":
+                XCTAssertEqual(right, "editions")
+                editions = true
+            case "editionsYear":
+                XCTAssertEqual(right, "editionsYear")
+                editionsYear = true
+            case "editionsRetailPrice":
+                XCTAssertEqual(right, "editionsRetailPrice")
+                editionsRetailPrice = true
+            case "editionsRating":
+                XCTAssertEqual(right, "editionsRating")
+                editionsRating = true
+            case "editionsAvailable":
+                XCTAssertEqual(right, "editionsAvailable")
+                editionsAvailable = true
+            default:
+                XCTFail()
+            }
+        }
+        XCTAssertTrue(entityId)
+        XCTAssertTrue(metadata)
+        XCTAssertTrue(acl)
+        XCTAssertTrue(title)
+        XCTAssertTrue(authorNames)
+        XCTAssertTrue(editions)
+        XCTAssertTrue(editionsYear)
+        XCTAssertTrue(editionsRetailPrice)
+        XCTAssertTrue(editionsRating)
+        XCTAssertTrue(editionsAvailable)
+    }
+    
 }
 
 class EntityWithDate : Entity {


### PR DESCRIPTION
#### Description

Implementing cascade delete since `find()` operations was ending up accumulating wasted objects in the database

#### Changes

* During `save()` the cache implementation now performs deletes on nested objects

#### Tests

* Making sure the nested objects are also being deleted
