### PR TITLE
MLIBZ-1979: unit test for query eq operator

### DIFF
--- a/Kinvey/Kinvey/ObjCRuntime.swift
+++ b/Kinvey/Kinvey/ObjCRuntime.swift
@@ -28,7 +28,8 @@ internal class ObjCRuntime: NSObject {
         let property = class_getProperty(cls, propertyName)
         let attributeValueCString = property_copyAttributeValue(property, "T")
         defer { free(attributeValueCString) }
-        if let attributeValue = String(validatingUTF8: attributeValueCString!),
+        if let attributeValueCString = attributeValueCString,
+            let attributeValue = String(validatingUTF8: attributeValueCString),
             let textCheckingResult = regexClassName.matches(in: attributeValue, range: NSMakeRange(0, attributeValue.characters.count)).first
         {
             let attributeValueNSString = attributeValue as NSString

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -246,9 +246,9 @@ extension XCTestCase {
         setURLProtocol(MockURLProtocol.self)
     }
     
-    func mockResponse(completionHandler: @escaping (URLRequest) -> HttpResponse) {
+    func mockResponse(client: Client = sharedClient, completionHandler: @escaping (URLRequest) -> HttpResponse) {
         MockURLProtocol.completionHandler = completionHandler
-        setURLProtocol(MockURLProtocol.self)
+        setURLProtocol(MockURLProtocol.self, client: client)
     }
     
 }


### PR DESCRIPTION
#### Description

Make sure the query `Query(format: "obj._id == %@", 30)` is being converted to `query={"obj._id":30}` and not `query={"obj":{"_id":30}}`

#### Changes

* No real changes

#### Tests

* Adding more test scenarios for query equals operator
