### PR TITLE
MLIBZ-1549: _id required, but not _kmd and _acl

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -58,9 +58,6 @@ open class Entity: Object, Persistable {
     
     /// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
     public required init?(map: Map) {
-        guard map[Key.entityId].isKeyPresent else {
-            return nil
-        }
         super.init()
     }
     

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -58,6 +58,9 @@ open class Entity: Object, Persistable {
     
     /// This function can be used to validate JSON prior to mapping. Return nil to cancel mapping at this point
     public required init?(map: Map) {
+        guard map[Key.entityId].isKeyPresent else {
+            return nil
+        }
         super.init()
     }
     

--- a/Kinvey/Kinvey/FindOperation.swift
+++ b/Kinvey/Kinvey/FindOperation.swift
@@ -66,6 +66,7 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
     
     @discardableResult
     func executeNetwork(_ completionHandler: CompletionHandler? = nil) -> Request {
+        let multiRequest = MultiRequest()
         let deltaSet = self.deltaSet && (cache != nil ? !cache!.isEmpty() : false)
         let fields: Set<String>? = deltaSet ? [Entity.Key.entityId, "\(Entity.Key.metadata).\(Metadata.Key.lastModifiedTime)"] : nil
         let request = client.networkRequestFactory.buildAppDataFindByQuery(
@@ -80,6 +81,18 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
                 self.resultsHandler?(jsonArray)
                 if let cache = self.cache, deltaSet {
                     let refObjs = self.reduceToIdsLmts(jsonArray)
+                    guard jsonArray.count == refObjs.count else {
+                        let operation = FindOperation(
+                            query: self.query,
+                            deltaSet: false,
+                            readPolicy: self.readPolicy,
+                            cache: cache,
+                            options: self.options
+                        )
+                        let request = operation.executeNetwork(completionHandler)
+                        multiRequest += request
+                        return
+                    }
                     let deltaSet = self.computeDeltaSet(self.query, refObjs: refObjs)
                     var allIds = Set<String>(minimumCapacity: deltaSet.created.count + deltaSet.updated.count + deltaSet.deleted.count)
                     allIds.formUnion(deltaSet.created)
@@ -200,7 +213,8 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
                 completionHandler?(.failure(buildError(data, response, error, self.client)))
             }
         }
-        return request
+        multiRequest += request
+        return multiRequest
     }
     
     fileprivate func removeCachedRecords<S : Sequence>(_ cache: AnyCache<T>, keys: S, deleted: Set<String>) where S.Iterator.Element == String {

--- a/Kinvey/Kinvey/FindOperation.swift
+++ b/Kinvey/Kinvey/FindOperation.swift
@@ -166,7 +166,9 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
                 } else {
                     func convert(_ jsonArray: [JsonDictionary]) -> AnyRandomAccessCollection<T> {
                         let startTime = CFAbsoluteTimeGetCurrent()
-                        let entities = AnyRandomAccessCollection(jsonArray.lazy.map {
+                        let entities = AnyRandomAccessCollection(jsonArray.lazy.filter {
+                            ($0[Entity.Key.entityId] as? String) != nil
+                        }.map {
                             T(JSON: $0)!
                         })
                         log.debug("Time elapsed: \(CFAbsoluteTimeGetCurrent() - startTime) s")

--- a/Kinvey/Kinvey/GetOperation.swift
+++ b/Kinvey/Kinvey/GetOperation.swift
@@ -48,6 +48,7 @@ internal class GetOperation<T: Persistable>: ReadOperation<T, T, Swift.Error>, R
             if let response = response,
                 response.isOK,
                 let json = self.client.responseParser.parse(data),
+                json[Entity.Key.entityId] != nil,
                 let obj = T(JSON: json)
             {
                 self.cache?.save(entity: obj)

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -194,6 +194,12 @@ func buildError(
     {
         return Error.appNotFound(description: description)
     } else if let response = response,
+        response.isOK,
+        let json = client.responseParser.parse(data),
+        json[Entity.Key.entityId] == nil
+    {
+        return Error.objectIdMissing
+    } else if let response = response,
         let json = client.responseParser.parse(data)
     {
         return Error.buildUnknownJsonError(

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -52,7 +52,7 @@ class DataTypeTestCase: StoreTestCase {
         
         mockResponse(json: [
             [
-                "_id" : Foundation.UUID().uuidString,
+                "_id" : UUID().uuidString,
                 "fullName2" : [
                     "lastName" : "Barros",
                     "fontDescriptor" : [
@@ -63,6 +63,7 @@ class DataTypeTestCase: StoreTestCase {
                 ],
                 "boolValue" : true,
                 "fullName" : [
+                    "_id" : UUID().uuidString,
                     "lastName" : "Barros",
                     "firstName" : "Victor"
                 ],

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -2356,4 +2356,37 @@ class NetworkStoreTests: StoreTestCase {
         }
     }
     
+    func testFindMissingId() {
+        let personName = "Victor"
+        mockResponse(json: [
+            [
+                "_id" : UUID().uuidString,
+                "name" : personName
+            ],
+            [
+                "name" : "\(personName) Barros"
+            ]
+        ])
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationFind = expectation(description: "Find")
+        
+        store.find(readPolicy: .forceNetwork) { persons, error in
+            XCTAssertNotNil(persons)
+            XCTAssertNil(error)
+            
+            if let persons = persons {
+                XCTAssertEqual(persons.count, 1)
+            }
+            
+            expectationFind?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFind = nil
+        }
+    }
+    
 }

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -2289,4 +2289,71 @@ class NetworkStoreTests: StoreTestCase {
         }.to(throwAssertion())
     }
     
+    func testGetMissingKmdAndAcl() {
+        let personId = UUID().uuidString
+        let personName = "Victor"
+        mockResponse(json: [
+            "_id" : personId,
+            "name" : personName
+        ])
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationFind = expectation(description: "Find")
+        
+        store.find(personId, readPolicy: .forceNetwork) { person, error in
+            XCTAssertNotNil(person)
+            XCTAssertNil(error)
+            
+            if let person = person {
+                XCTAssertNotNil(person.entityId)
+                XCTAssertEqual(person.personId, personId)
+                XCTAssertEqual(person.name, personName)
+                XCTAssertNil(person.metadata)
+                XCTAssertNil(person.acl)
+            }
+            
+            expectationFind?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFind = nil
+        }
+    }
+    
+    func testGetMissingId() {
+        let personId = UUID().uuidString
+        let personName = "Victor"
+        mockResponse(json: [
+            "name" : personName
+        ])
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationFind = expectation(description: "Find")
+        
+        store.find(personId, readPolicy: .forceNetwork) { person, error in
+            XCTAssertNil(person)
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(error as? Kinvey.Error)
+            
+            if let error = error as? Kinvey.Error {
+                switch error {
+                case .objectIdMissing:
+                    break
+                default:
+                    XCTFail()
+                }
+            }
+            
+            expectationFind?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFind = nil
+        }
+    }
+    
 }


### PR DESCRIPTION
#### Description

Make _id required, but not _kmd and _acl

#### Changes

* `Entity` now validates if `_id` is present

#### Tests

* Unit test to check if is ok if `_kmd` or `_acl` is missing
* Unit test to check if `_id` is missing in a `find(byId:)` throws an error
* Unit test to check if `_id` is missing in a `find()` returns an empty array
