### PR TITLE
MLIBZ-2058: fixing the cache path when running on macOS

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		57C731F21F575DBB00B67C13 /* Realm.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57B0C1E71CDCE88900492D6C /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57C731F31F575DC600B67C13 /* RealmSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57B0C1E91CDCE88900492D6C /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57C731F41F575DD100B67C13 /* XCGLogger.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 577751391DF8B908006C98F1 /* XCGLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		57C731FA1F57721700B67C13 /* MacOSOnlyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C731F91F57721700B67C13 /* MacOSOnlyTestCase.swift */; };
 		57D386A21CC19D0C0014050D /* Kinvey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57D386A31CC19D7C0014050D /* Kinvey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57D643001CA3268000F6D16E /* CacheMigrationTestCaseStep1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577155531CA1D65D00C91B4B /* CacheMigrationTestCaseStep1.swift */; };
@@ -923,6 +924,7 @@
 		57BEAE341C98AB3900479206 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		57C2F1721D5E5A68005A214B /* BuilderType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuilderType.swift; sourceTree = "<group>"; };
 		57C71DC71C3EFBF900B1BEF2 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		57C731F91F57721700B67C13 /* MacOSOnlyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacOSOnlyTestCase.swift; sourceTree = "<group>"; };
 		57D643141CA3268000F6D16E /* KinveyTests Migration Database Step 1.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KinveyTests Migration Database Step 1.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		57D6433B1CA3268600F6D16E /* KinveyTests Migration Database Step 2.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KinveyTests Migration Database Step 2.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		57D6433D1CA326DE00F6D16E /* CacheMigrationTestCaseStep2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheMigrationTestCaseStep2.swift; sourceTree = "<group>"; };
@@ -1191,6 +1193,7 @@
 				5705B1CE1EDF823F0006980A /* Info.plist */,
 				5706231F1F1825CA00B7FAE9 /* PerformanceTest.swift */,
 				578148581F2BCC5D009E8622 /* HierarchyCache.swift */,
+				57C731F91F57721700B67C13 /* MacOSOnlyTestCase.swift */,
 			);
 			path = KinveyMacAppTests;
 			sourceTree = "<group>";
@@ -2568,6 +2571,7 @@
 				578B80501EE73A77004D92A6 /* Person.swift in Sources */,
 				5705B1CD1EDF823F0006980A /* RealtimeMacAppTests.swift in Sources */,
 				578B80511EE73A84004D92A6 /* MockKinveyBackend.swift in Sources */,
+				57C731FA1F57721700B67C13 /* MacOSOnlyTestCase.swift in Sources */,
 				570623201F1825CA00B7FAE9 /* PerformanceTest.swift in Sources */,
 				578B805C1EE73BF2004D92A6 /* DataTypeTestCase.swift in Sources */,
 				578B806A1EE746B9004D92A6 /* MetadataTestCase.swift in Sources */,

--- a/Kinvey/Kinvey/Cache.swift
+++ b/Kinvey/Kinvey/Cache.swift
@@ -104,8 +104,11 @@ class AnyCache<T: Persistable>: CacheType {
     private let _detach: (AnyRandomAccessCollection<Type>, Query?) -> AnyRandomAccessCollection<Type>
     
     typealias `Type` = T
+    
+    let cache: Any
 
     init<Cache: CacheType>(_ cache: Cache) where Cache.`Type` == T {
+        self.cache = cache
         _getDynamic = { return cache.dynamic }
         _getTTL = { return cache.ttl }
         _setTTL = { cache.ttl = $0 }

--- a/Kinvey/Kinvey/CacheManager.swift
+++ b/Kinvey/Kinvey/CacheManager.swift
@@ -41,28 +41,27 @@ internal class CacheManager: NSObject {
     }
     
     func clearAll(_ tag: String? = nil) {
-        if let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first {
-            let basePath = (path as NSString).appendingPathComponent(persistenceId)
-            
-            let fileManager = FileManager.default
-            
-            var isDirectory = ObjCBool(false)
-            let exists = fileManager.fileExists(atPath: basePath, isDirectory: &isDirectory)
-            if exists && isDirectory.boolValue {
-                var array = try! fileManager.subpathsOfDirectory(atPath: basePath)
-                array = array.filter({ (path) -> Bool in
-                    return path.hasSuffix(".realm") && (tag == nil || path.caseInsensitiveCompare(tag! + ".realm") == .orderedSame)
-                })
-                for realmFile in array {
-                    var realmConfiguration = Realm.Configuration.defaultConfiguration
-                    realmConfiguration.fileURL = URL(fileURLWithPath: (basePath as NSString).appendingPathComponent(realmFile))
-                    if let encryptionKey = encryptionKey {
-                        realmConfiguration.encryptionKey = encryptionKey
-                    }
-                    if let realm = try? Realm(configuration: realmConfiguration), !realm.isEmpty {
-                        try! realm.write {
-                            realm.deleteAll()
-                        }
+        let path = cacheBasePath
+        let basePath = (path as NSString).appendingPathComponent(persistenceId)
+        
+        let fileManager = FileManager.default
+        
+        var isDirectory = ObjCBool(false)
+        let exists = fileManager.fileExists(atPath: basePath, isDirectory: &isDirectory)
+        if exists && isDirectory.boolValue {
+            var array = try! fileManager.subpathsOfDirectory(atPath: basePath)
+            array = array.filter({ (path) -> Bool in
+                return path.hasSuffix(".realm") && (tag == nil || path.caseInsensitiveCompare(tag! + ".realm") == .orderedSame)
+            })
+            for realmFile in array {
+                var realmConfiguration = Realm.Configuration.defaultConfiguration
+                realmConfiguration.fileURL = URL(fileURLWithPath: (basePath as NSString).appendingPathComponent(realmFile))
+                if let encryptionKey = encryptionKey {
+                    realmConfiguration.encryptionKey = encryptionKey
+                }
+                if let realm = try? Realm(configuration: realmConfiguration), !realm.isEmpty {
+                    try! realm.write {
+                        realm.deleteAll()
                     }
                 }
             }

--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -315,8 +315,7 @@ open class Client: Credential {
     }
     
     internal class func fileURL(appKey: String, tag: String = defaultTag) -> URL {
-        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-        let path = paths.first! as NSString
+        let path = cacheBasePath as NSString
         var filePath = URL(fileURLWithPath: path.appendingPathComponent(appKey))
         filePath.appendPathComponent("\(tag).realm")
         return filePath

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -759,9 +759,9 @@ open class FileStore<FileType: File> {
                             fulfill(pathURL)
                         } else {
                             let fileManager = FileManager()
-                            if let entityId = entityId,
-                                let baseFolder = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first
+                            if let entityId = entityId
                             {
+                                let baseFolder = cacheBasePath
                                 do {
                                     var baseFolderURL = URL(fileURLWithPath: baseFolder)
                                     baseFolderURL = baseFolderURL.appendingPathComponent(self.client.appKey!).appendingPathComponent("files")

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -116,7 +116,14 @@ public var logLevel: LogLevel = log.outputLevel.logLevel {
 
 let defaultTag = "kinvey"
 
-let userDocumentDirectory: String = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+#if os(macOS)
+    fileprivate var applicationSupportDirectoryURL: URL = {
+        return URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!)
+    }()
+    let cacheBasePath = applicationSupportDirectoryURL.appendingPathComponent(Bundle.main.bundleIdentifier!).path
+#else
+    let cacheBasePath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+#endif
 
 func buildError(_ data: Data?, _ response: Response?, _ error: Swift.Error?, _ client: Client) -> Swift.Error {
     return buildError(data: data, response: response, error: error, client: client)

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -117,10 +117,7 @@ public var logLevel: LogLevel = log.outputLevel.logLevel {
 let defaultTag = "kinvey"
 
 #if os(macOS)
-    fileprivate var applicationSupportDirectoryURL: URL = {
-        return URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!)
-    }()
-    let cacheBasePath = applicationSupportDirectoryURL.appendingPathComponent(Bundle.main.bundleIdentifier!).path
+    let cacheBasePath = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!).appendingPathComponent(Bundle.main.bundleIdentifier!).path
 #else
     let cacheBasePath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
 #endif

--- a/Kinvey/KinveyMacAppTests/MacOSOnlyTestCase.swift
+++ b/Kinvey/KinveyMacAppTests/MacOSOnlyTestCase.swift
@@ -1,0 +1,41 @@
+//
+//  MacOSOnlyTestCase.swift
+//  Kinvey
+//
+//  Created by Victor Hugo on 2017-08-30.
+//  Copyright © 2017 Kinvey. All rights reserved.
+//
+
+import XCTest
+@testable import Kinvey
+
+class MacOSOnlyTestCase: KinveyTestCase {
+    
+    func testCachePath() {
+        let dataStore = DataStore<Person>.collection(.sync)
+        let person = Person()
+        person.name = "Victor"
+        
+        weak var expectationSave = expectation(description: "Save")
+        
+        dataStore.save(person, options: nil) { (result: Result<Person, Swift.Error>) in
+            switch result {
+            case .success:
+                break
+            case .failure:
+                XCTFail()
+            }
+            
+            expectationSave?.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10) { error in
+            expectationSave = nil
+        }
+        
+        let realmCache = dataStore.cache?.cache as? RealmCache<Person>
+        let basePath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
+        XCTAssertEqual(realmCache?.configuration.fileURL?.path, "\(basePath)/\(Bundle.main.bundleIdentifier!)/_kid_/kinvey.realm")
+    }
+    
+}

--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -380,7 +380,7 @@ class CacheStoreTests: StoreTestCase {
         }
         
         do {
-            let basePath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+            let basePath = Kinvey.cacheBasePath
             var url = URL(fileURLWithPath: basePath)
             url = url.appendingPathComponent(sharedClient.appKey!)
             url = url.appendingPathComponent("kinvey.realm")

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -109,48 +109,45 @@ class SyncStoreTests: StoreTestCase {
     func testCustomTag() {
         let fileManager = FileManager.default
         
-        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-        XCTAssertEqual(paths.count, 1)
-        if let path = paths.first {
-            let tag = "Custom Identifier"
-            let customPath = "\(path)/\(client.appKey!)/\(tag).realm"
-            
-            let removeFiles: () -> Void = {
-                if fileManager.fileExists(atPath: customPath) {
-                    try! fileManager.removeItem(atPath: customPath)
-                }
-                
-                let lockPath = (customPath as NSString).appendingPathExtension("lock")!
-                if fileManager.fileExists(atPath: lockPath) {
-                    try! fileManager.removeItem(atPath: lockPath)
-                }
-                
-                let logPath = (customPath as NSString).appendingPathExtension("log")!
-                if fileManager.fileExists(atPath: logPath) {
-                    try! fileManager.removeItem(atPath: logPath)
-                }
-                
-                let logAPath = (customPath as NSString).appendingPathExtension("log_a")!
-                if fileManager.fileExists(atPath: logAPath) {
-                    try! fileManager.removeItem(atPath: logAPath)
-                }
-                
-                let logBPath = (customPath as NSString).appendingPathExtension("log_b")!
-                if fileManager.fileExists(atPath: logBPath) {
-                    try! fileManager.removeItem(atPath: logBPath)
-                }
+        let path = cacheBasePath
+        let tag = "Custom Identifier"
+        let customPath = "\(path)/\(client.appKey!)/\(tag).realm"
+        
+        let removeFiles: () -> Void = {
+            if fileManager.fileExists(atPath: customPath) {
+                try! fileManager.removeItem(atPath: customPath)
             }
             
+            let lockPath = (customPath as NSString).appendingPathExtension("lock")!
+            if fileManager.fileExists(atPath: lockPath) {
+                try! fileManager.removeItem(atPath: lockPath)
+            }
+            
+            let logPath = (customPath as NSString).appendingPathExtension("log")!
+            if fileManager.fileExists(atPath: logPath) {
+                try! fileManager.removeItem(atPath: logPath)
+            }
+            
+            let logAPath = (customPath as NSString).appendingPathExtension("log_a")!
+            if fileManager.fileExists(atPath: logAPath) {
+                try! fileManager.removeItem(atPath: logAPath)
+            }
+            
+            let logBPath = (customPath as NSString).appendingPathExtension("log_b")!
+            if fileManager.fileExists(atPath: logBPath) {
+                try! fileManager.removeItem(atPath: logBPath)
+            }
+        }
+        
+        removeFiles()
+        XCTAssertFalse(fileManager.fileExists(atPath: customPath))
+        
+        store = DataStore<Person>.collection(.sync, tag: tag)
+        defer {
             removeFiles()
             XCTAssertFalse(fileManager.fileExists(atPath: customPath))
-            
-            store = DataStore<Person>.collection(.sync, tag: tag)
-            defer {
-                removeFiles()
-                XCTAssertFalse(fileManager.fileExists(atPath: customPath))
-            }
-            XCTAssertTrue(fileManager.fileExists(atPath: customPath))
         }
+        XCTAssertTrue(fileManager.fileExists(atPath: customPath))
     }
     
     func testPurge() {


### PR DESCRIPTION
#### Description

Cache path on macOS was `~/Documents/<kid>`, but should be `~/Library/Application Support/<bundle id>/<kid>`

#### Changes

* `Kinvey.swift` now contains a `internal` `cacheBasePath` and the rest of the code should use it

#### Tests

* Unit test that check if the cache is being saved in the right path
