### PR TITLE
MLIBZ-1502: logout async

### DIFF
--- a/Kinvey/Kinvey/Endpoint.swift
+++ b/Kinvey/Kinvey/Endpoint.swift
@@ -16,6 +16,7 @@ internal enum Endpoint {
     case userLookup(client: Client)
     case userExistsByUsername(client: Client)
     case userLogin(client: Client)
+    case userLogout(client: Client)
     case sendEmailConfirmation(client: Client, username: String)
     case userResetPassword(usernameOrEmail: String, client: Client)
     case userForgotUsername(client: Client)
@@ -84,6 +85,8 @@ internal enum Endpoint {
             return client.apiHostName.appendingPathComponent("/rpc/\(client.appKey!)/check-username-exists")
         case .userLogin(let client):
             return client.apiHostName.appendingPathComponent("/user/\(client.appKey!)/login")
+        case .userLogout(let client):
+            return client.apiHostName.appendingPathComponent("/user/\(client.appKey!)/_logout")
         case .sendEmailConfirmation(let client, let username):
             return client.apiHostName.appendingPathComponent("/rpc/\(client.appKey!)/\(username)/user-email-verification-initiate")
         case .userResetPassword(let usernameOrEmail, let client):

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -127,6 +127,19 @@ class HttpRequestFactory: RequestFactory {
         return request
     }
     
+    func buildUserLogout(
+        user: User,
+        options: Options?
+    ) -> HttpRequest {
+        let request = HttpRequest(
+            httpMethod: .post,
+            endpoint: Endpoint.userLogout(client: client),
+            credential: client.activeUser,
+            options: options
+        )
+        return request
+    }
+    
     func buildUserExists(
         username: String,
         options: Options?

--- a/Kinvey/Kinvey/RequestFactory.swift
+++ b/Kinvey/Kinvey/RequestFactory.swift
@@ -17,6 +17,7 @@ protocol RequestFactory {
     func buildUserSocialCreate(_ authSource: AuthSource, authData: [String : Any], options: Options?) -> HttpRequest
     
     func buildUserLogin(username: String, password: String, options: Options?) -> HttpRequest
+    func buildUserLogout(user: User, options: Options?) -> HttpRequest
     func buildUserExists(username: String, options: Options?) -> HttpRequest
     func buildUserGet(userId: String, options: Options?) -> HttpRequest
     func buildUserFind(query: Query, options: Options?) -> HttpRequest

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -3865,6 +3865,40 @@ extension UserTests {
         }
     }
     
+    func testLogout() {
+        signUp()
+        
+        guard let user = Kinvey.sharedClient.activeUser else {
+            Swift.fatalError()
+        }
+        
+        if useMockData {
+            mockResponse(statusCode: 204, data: Data())
+        }
+        defer {
+            if useMockData {
+                setURLProtocol(nil)
+            }
+        }
+        
+        weak var expectationLogout = expectation(description: "Logout")
+        
+        user.logout {
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            
+            expectationLogout?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationLogout = nil
+        }
+    }
+    
 }
 
 #endif

--- a/Kinvey/SSOApp/SSOApp1Tests/SSOApp1Tests.swift
+++ b/Kinvey/SSOApp/SSOApp1Tests/SSOApp1Tests.swift
@@ -142,6 +142,11 @@ class SSOApp1Tests: KinveyTestCase {
                     client?.urlProtocol(self, didLoad: data)
                     
                     client?.urlProtocolDidFinishLoading(self)
+                case "/user/\(MockURLProtocol.appKey ?? "")/_logout":
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "1.1", headerFields: [:])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    client?.urlProtocol(self, didLoad: Data())
+                    client?.urlProtocolDidFinishLoading(self)
                 default:
                     XCTFail("URL Path not handled: \(request.url!.path)")
                 }

--- a/Kinvey/SSOApp/SSOApp2Tests/SSOApp2Tests.swift
+++ b/Kinvey/SSOApp/SSOApp2Tests/SSOApp2Tests.swift
@@ -68,6 +68,11 @@ class SSOApp2Tests: KinveyTestCase {
                     client?.urlProtocol(self, didLoad: data)
                     
                     client?.urlProtocolDidFinishLoading(self)
+                case "/user/appKey/_logout":
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "1.1", headerFields: [:])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    client?.urlProtocol(self, didLoad: Data())
+                    client?.urlProtocolDidFinishLoading(self)
                 default:
                     XCTFail("URL Path not handled: \(request.url!.path)")
                 }


### PR DESCRIPTION
#### Description

Make the `logout()` async which will end up invalidating the current auth token

#### Changes

* Adding optional parameters to the `logout()` method

#### Tests

* Unit testing mocking the response from the server
