### PR TITLE
MLIBZ-2088: bugfix register for push must be called in main thread

### DIFF
--- a/Kinvey/Kinvey/Push.swift
+++ b/Kinvey/Kinvey/Push.swift
@@ -253,7 +253,9 @@ open class Push {
                     options: options,
                     completionHandler: completionHandler
                 )
-                UIApplication.shared.registerForRemoteNotifications()
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
             } else {
                 if let error = error {
                     completionHandler?(.failure(error))


### PR DESCRIPTION
#### Description

Bug detected after Xcode 9 came out

#### Changes

* Making sure `UIApplication.shared.registerForRemoteNotifications()` is being called in the main thread

#### Tests

* Hard to have a unit test for since this is around push notifications
