### PR TITLE
MLIBZ-2087: allow users to retrieve the acl for a live stream

### DIFF
--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -711,6 +711,20 @@ class HttpRequestFactory: RequestFactory {
         return request
     }
     
+    func buildLiveStreamAccess(
+        streamName: String,
+        userId: String,
+        options: Options?
+    ) -> HttpRequest {
+        let request = HttpRequest(
+            httpMethod: .get,
+            endpoint: Endpoint.liveStreamByUser(client: options?.client ?? self.client, streamName: streamName, userId: userId),
+            credential: client.activeUser,
+            options: options
+        )
+        return request
+    }
+    
     func buildLiveStreamPublish(
         streamName: String,
         userId: String,

--- a/Kinvey/Kinvey/RequestFactory.swift
+++ b/Kinvey/Kinvey/RequestFactory.swift
@@ -59,6 +59,7 @@ protocol RequestFactory {
     func buildOAuthGrantRefreshToken(refreshToken: String, options: Options?) -> HttpRequest
     
     func buildLiveStreamGrantAccess(streamName: String, userId: String, acl: LiveStreamAcl, options: Options?) -> HttpRequest
+    func buildLiveStreamAccess(streamName: String, userId: String, options: Options?) -> HttpRequest
     func buildLiveStreamPublish(streamName: String, userId: String, options: Options?) -> HttpRequest
     func buildLiveStreamSubscribe(streamName: String, userId: String, deviceId: String, options: Options?) -> HttpRequest
     func buildLiveStreamUnsubscribe(streamName: String, userId: String, deviceId: String, options: Options?) -> HttpRequest


### PR DESCRIPTION
#### Description

Allow users to retrieve the acl for a live stream

#### Changes

* Add a new method call `streamAccess()`, following a similar name to grant access, which is `grantStreamAccess()`

#### Tests

* Add a check in a existing unit test
