### PR TITLE
MLIBZ-2095: bugfix for the infinite loop if dynamic keyword is not used

### DIFF
--- a/Kinvey/BackgroundFetch/AppDelegate.swift
+++ b/Kinvey/BackgroundFetch/AppDelegate.swift
@@ -12,7 +12,7 @@ import PromiseKit
 
 class Book: Entity {
     
-    var name: String?
+    dynamic var name: String?
     
     override class func collectionName() -> String {
         return "Book"
@@ -96,27 +96,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         var promises = [AnyPromise]()
         
-//        let promiseDataStore = Promise<AnyRandomAccessCollection<Book>> { fulfill, reject in
-//            print("DataStore find")
-//            self.dataStore.find { (result: Kinvey.Result<AnyRandomAccessCollection<Book>, Swift.Error>) in
-//                switch result {
-//                case .success(let books):
-//                    print("\(books.count) Book(s)")
-//                    fulfill(books)
-//                case .failure(let error):
-//                    print(error)
-//                    reject(error)
-//                }
-//            }
-//        }
-//        promises.append(AnyPromise(promiseDataStore))
+        let promiseDataStore = Promise<AnyRandomAccessCollection<Book>> { fulfill, reject in
+            print("DataStore find")
+            self.dataStore.find { (result: Kinvey.Result<AnyRandomAccessCollection<Book>, Swift.Error>) in
+                switch result {
+                case .success(let books):
+                    print("\(books.count) Book(s)")
+                    fulfill(books)
+                case .failure(let error):
+                    print(error)
+                    reject(error)
+                }
+            }
+        }
+        promises.append(AnyPromise(promiseDataStore))
         
         let promiseFileStore = Promise<[File]> { fulfill, reject in
             print("Files find")
             self.fileStore.find(options: nil) { (result: Kinvey.Result<[File], Swift.Error>) in
                 switch result {
                 case .success(let files):
-                    print(files)
+                    print("\(files.count) File(s)")
                     fulfill(files)
                 case .failure(let error):
                     print(error)
@@ -126,9 +126,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         promises.append(AnyPromise(promiseFileStore))
         
-        when(fulfilled: promises.map { $0.asPromise() }).then { _ in
+        when(fulfilled: promises.map { $0.asPromise() }).then { (result) -> Void in
+            print("completionHandler new data")
             completionHandler(.newData)
-        }.catch { _ in
+        }.catch { (error) -> Void in
+            print("completionHandler failed")
             completionHandler(.failed)
         }
     }


### PR DESCRIPTION
#### Description

Bugfix for the infinite loop in case the user forgets to add the `dynamic` keyword in the property

#### Changes

* Fixing the `ObjCRuntime` class to not get stucked in a infinite loop in case the property does not have a `dynamic` keyword

#### Tests

* Since this is a infinite loop it's hard to find a way to write a unit test for it
