### PR TITLE
MLIBZ-2096: allow custom URLSessions

### DIFF
--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -585,7 +585,8 @@ open class FileStore<FileType: File> {
                     }
                 }
                 
-                let dataTask = self.client.urlSession.dataTask(with: request) { (data, response, error) in
+                let urlSession = options?.urlSession ?? client.urlSession
+                let dataTask = urlSession.dataTask(with: request) { (data, response, error) in
                     if self.client.logNetworkEnabled, let response = response as? HTTPURLResponse {
                         do {
                             log.debug("\(response.description(data))")
@@ -615,7 +616,7 @@ open class FileStore<FileType: File> {
                         reject(buildError(data, HttpResponse(response: response), error, self.client))
                     }
                 }
-                requests += URLSessionTaskRequest(client: client, task: dataTask)
+                requests += URLSessionTaskRequest(client: client, options: options, task: dataTask)
                 dataTask.resume()
             } else {
                 createUpdateFileEntry()
@@ -627,6 +628,7 @@ open class FileStore<FileType: File> {
         _ file: FileType,
         fromSource source: InputSource,
         skip: Int?,
+        options: Options?,
         requests: MultiRequest
     ) -> Promise<FileType> {
         return Promise<FileType> { fulfill, reject in
@@ -659,6 +661,8 @@ open class FileStore<FileType: File> {
                 }
             }
             
+            let urlSession = options?.urlSession ?? client.urlSession
+            
             switch source {
             case let .data(data):
                 let uploadData: Data
@@ -676,10 +680,10 @@ open class FileStore<FileType: File> {
                     }
                 }
                 
-                let uploadTask = self.client.urlSession.uploadTask(with: request, from: uploadData) { (data, response, error) -> Void in
+                let uploadTask = urlSession.uploadTask(with: request, from: uploadData) { (data, response, error) -> Void in
                     handler(data, response, error)
                 }
-                requests += (URLSessionTaskRequest(client: self.client, task: uploadTask), addProgress: true)
+                requests += (URLSessionTaskRequest(client: self.client, options: options, task: uploadTask), addProgress: true)
                 uploadTask.resume()
             case let .url(url):
                 if self.client.logNetworkEnabled {
@@ -688,10 +692,10 @@ open class FileStore<FileType: File> {
                     }
                 }
                 
-                let uploadTask = self.client.urlSession.uploadTask(with: request, fromFile: url) { (data, response, error) -> Void in
+                let uploadTask = urlSession.uploadTask(with: request, fromFile: url) { (data, response, error) -> Void in
                     handler(data, response, error)
                 }
-                requests += (URLSessionTaskRequest(client: self.client, task: uploadTask), addProgress: true)
+                requests += (URLSessionTaskRequest(client: self.client, options: options, task: uploadTask), addProgress: true)
                 uploadTask.resume()
             case let .stream(stream):
                 request.httpBodyStream = stream
@@ -702,10 +706,10 @@ open class FileStore<FileType: File> {
                     }
                 }
                 
-                let dataTask = self.client.urlSession.dataTask(with: request) { (data, response, error) -> Void in
+                let dataTask = urlSession.dataTask(with: request) { (data, response, error) -> Void in
                     handler(data, response, error)
                 }
-                requests += (URLSessionTaskRequest(client: self.client, task: dataTask), addProgress: true)
+                requests += (URLSessionTaskRequest(client: self.client, options: options, task: dataTask), addProgress: true)
                 dataTask.resume()
             }
         }
@@ -729,6 +733,7 @@ open class FileStore<FileType: File> {
                 file,
                 fromSource: source,
                 skip: skip,
+                options: options,
                 requests: requests
             )
         }.then { file in //fetching download url
@@ -805,12 +810,13 @@ open class FileStore<FileType: File> {
     fileprivate func downloadFileURL(
         _ file: FileType,
         storeType: StoreType = .cache,
-        downloadURL: URL
+        downloadURL: URL,
+        options: Options?
     ) -> (
         request: URLSessionTaskRequest,
         promise: Promise<URL>
     ) {
-        let downloadTaskRequest = URLSessionTaskRequest(client: client, url: downloadURL)
+        let downloadTaskRequest = URLSessionTaskRequest(client: client, options: options, url: downloadURL)
         let promise = Promise<URL> { fulfill, reject in
             let executor = Executor()
             downloadTaskRequest.downloadTaskWithURL(file) { (url: URL?, response, error) in
@@ -870,8 +876,8 @@ open class FileStore<FileType: File> {
     }
     
     @discardableResult
-    fileprivate func downloadFileData(_ file: FileType, downloadURL: URL) -> (request: URLSessionTaskRequest, promise: Promise<Data>) {
-        let downloadTaskRequest = URLSessionTaskRequest(client: client, url: downloadURL)
+    fileprivate func downloadFileData(_ file: FileType, downloadURL: URL, options: Options?) -> (request: URLSessionTaskRequest, promise: Promise<Data>) {
+        let downloadTaskRequest = URLSessionTaskRequest(client: client, options: options, url: downloadURL)
         let promise = downloadTaskRequest.downloadTaskWithURL(file).then { data, response -> Promise<Data> in
             return Promise<Data> { fulfill, reject in
                 fulfill(data)
@@ -990,7 +996,8 @@ open class FileStore<FileType: File> {
                 let (request, promise) = self.downloadFileURL(
                     file,
                     storeType: storeType,
-                    downloadURL: downloadURL
+                    downloadURL: downloadURL,
+                    options: options
                 )
                 multiRequest += (request, true)
                 return promise.then { localUrl in
@@ -1107,7 +1114,8 @@ open class FileStore<FileType: File> {
             case .downloadURL(let downloadURL):
                 let (request, promise) = self.downloadFileData(
                     file,
-                    downloadURL: downloadURL
+                    downloadURL: downloadURL,
+                    options: options
                 )
                 multiRequest += (request, addProgress: true)
                 return promise

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -400,7 +400,7 @@ internal class HttpRequest: TaskProgressRequest, Request {
             }
         }
         
-        let urlSession = urlSession ?? client.urlSession
+        let urlSession = urlSession ?? options?.urlSession ?? client.urlSession
         task = urlSession.dataTask(with: request) { (data, response, error) -> Void in
             if let response = response as? HTTPURLResponse {
                 if self.client.logNetworkEnabled {

--- a/Kinvey/Kinvey/MIC.swift
+++ b/Kinvey/Kinvey/MIC.swift
@@ -145,7 +145,7 @@ open class MIC {
                     password: password,
                     options: options
                 )
-                let urlSession = URLSession(
+                let urlSession = options?.urlSession ?? URLSession(
                     configuration: client.urlSession.configuration,
                     delegate: URLSessionDelegateAdapter(),
                     delegateQueue: nil

--- a/Kinvey/Kinvey/RequestFactory.swift
+++ b/Kinvey/Kinvey/RequestFactory.swift
@@ -71,6 +71,9 @@ public struct Options {
     /// Custom `Client` instance
     public var client: Client?
     
+    /// Custom `URLSession` instance
+    public var urlSession: URLSession?
+    
     /// Custom `authServiceId` value used for MIC
     public var authServiceId: String?
     
@@ -101,6 +104,7 @@ public struct Options {
      */
     public init(
         client: Client? = nil,
+        urlSession: URLSession? = nil,
         authServiceId: String? = nil,
         ttl: TTL? = nil,
         deltaSet: Bool? = nil,
@@ -111,6 +115,7 @@ public struct Options {
         customRequestProperties: [String : Any]? = nil
     ) {
         self.client = client
+        self.urlSession = urlSession
         self.authServiceId = authServiceId
         self.ttl = ttl
         self.deltaSet = deltaSet


### PR DESCRIPTION
#### Description

Allow custom URLSessions for background calls for example

#### Changes

* Added a property called `urlSession` in the `Options` class
* Changed all places where a URLSession is used

#### Tests

* No need to add unit tests
