### PR TITLE
MLIBZ-2102: bugfix for sync since it was not filtering by collection

### DIFF
--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -41,7 +41,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
     }
     
     func createPendingOperation(_ request: URLRequest, objectId: String?) -> PendingOperationType {
-        return RealmPendingOperation(request: request, collectionName: T.collectionName(), objectId: objectId)
+        return RealmPendingOperation(request: request, collectionName: collectionName, objectId: objectId)
     }
     
     func savePendingOperation(_ pendingOperation: PendingOperationType) {
@@ -63,7 +63,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
         log.verbose("Fetching pending operations")
         var results: [PendingOperationType]?
         executor.executeAndWait {
-            results = self.realm.objects(RealmPendingOperation.self).map {
+            results = self.realm.objects(RealmPendingOperation.self).filter("collectionName == %@", self.collectionName).map {
                 return RealmPendingOperationThreadSafeReference($0)
             }
         }
@@ -84,7 +84,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
         log.verbose("Removing pending operations by object id: \(String(describing: objectId))")
         executor.executeAndWait {
             try! self.realm.write {
-                var realmResults = self.realm.objects(RealmPendingOperation.self)
+                var realmResults = self.realm.objects(RealmPendingOperation.self).filter("collectionName == %@", self.collectionName)
                 if let objectId = objectId {
                     realmResults = realmResults.filter("objectId == %@", objectId)
                 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -667,6 +667,30 @@ class SyncStoreTests: StoreTestCase {
     func testPush() {
         save()
         
+        let bookDataStore = DataStore<Book>.collection(.sync)
+        
+        do {
+            let book = Book()
+            book.title = "Les Miserables"
+            
+            weak var expectationSave = expectation(description: "Save Book")
+            
+            bookDataStore.save(book, options: nil) { (result: Result<Book, Swift.Error>) in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+                
+                expectationSave?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationSave = nil
+            }
+        }
+        
         XCTAssertEqual(store.syncCount(), 1)
         
         if useMockData {


### PR DESCRIPTION
#### Description

Bugfix for sync since it was not filtering by collection

#### Changes

* Filtering pending operations by collection at `RealmSync`

#### Tests

* Checking if the `syncCount()` and the result of a `sync()` calls results in the expected number of entities being pushed
