### PR TITLE
MLIBZ-2111: bugfix transforms were being ignored when saving object using dynamic Realm

### DIFF
--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -617,6 +617,8 @@ extension RealmCache: DynamicCacheType {
                         translatedEntity[translatedKey] = array.map {
                             return ["value" : $0]
                         }
+                    } else if let transform = transform {
+                        translatedEntity[translatedKey] = transform.transformFromJSON(entity[key])
                     } else {
                         translatedEntity[translatedKey] = entity[key]
                     }

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-macos:
 pack:
 	mkdir -p build/Kinvey-$(VERSION)
 	cd Carthage/Build; \
-	find . -name "*.framework" ! -name "KIF.framework" ! -name "Nimble.framework" | awk '{split($$0, array, "/"); system("mkdir -p ../../build/Kinvey-$(VERSION)/" array[2] " && cp -R " array[2] "/" array[3] " ../../build/Kinvey-$(VERSION)/" array[2])}'
+	find . -name "*.framework" ! -name "KIF.framework" ! -name "Nimble.framework" ! -name "Swifter.framework" | awk '{split($$0, array, "/"); system("mkdir -p ../../build/Kinvey-$(VERSION)/" array[2] " && cp -R " array[2] "/" array[3] " ../../build/Kinvey-$(VERSION)/" array[2])}'
 	cd build; \
 	zip -r Kinvey-$(VERSION).zip Kinvey-$(VERSION)
 

--- a/scripts/devcenter-release/main.swift
+++ b/scripts/devcenter-release/main.swift
@@ -49,9 +49,9 @@ let downloadURLString = "http://download.kinvey.com/iOS/Kinvey-\(version).zip"
 let versionTuple: (major: Int, minor: Int, patch: Int) = {
     let regex = try! NSRegularExpression(pattern: "(\\d)\\.(\\d)\\.(\\d)")
     let match = regex.firstMatch(in: version, range: NSRange(location: 0, length: version.characters.count))!
-    let major = Int(version[match.rangeAt(1)])!
-    let minor = Int(version[match.rangeAt(2)])!
-    let patch = Int(version[match.rangeAt(3)])!
+    let major = Int(version[match.range(at: 1)])!
+    let minor = Int(version[match.range(at: 2)])!
+    let patch = Int(version[match.range(at: 3)])!
     return (major: major, minor: minor, patch: patch)
 }()
 let session = URLSession.shared
@@ -95,7 +95,7 @@ func convertBody(body: String) -> String {
         if let match = regexHeader.firstMatch(in: line, range: NSRange(location: 0, length: line.characters.count)),
             match.numberOfRanges > 1
         {
-            currentHeader = line[match.rangeAt(1)]
+            currentHeader = line[match.range(at: 1)]
             switch currentHeader {
             case "Improvements"?:
                 currentHeader = "Improvement"
@@ -109,7 +109,7 @@ func convertBody(body: String) -> String {
         } else if let currentHeader = currentHeader,
             let match = regexTopic.firstMatch(in: line, range: NSRange(location: 0, length: line.characters.count)),
             match.numberOfRanges > 1,
-            let line = Optional(line[match.rangeAt(1)]),
+            let line = Optional(line[match.range(at: 1)]),
             line != "None"
         {
             result += "* \(currentHeader): \(line)\n"
@@ -128,8 +128,8 @@ func changeDownloadsJson(pathURL: URL) {
     let regexKeyValue = try! NSRegularExpression(pattern: "\"([^\"]*)\"\\s*:\\s*\"([^\"]*)\"")
     for match in regexKeyValue.matches(in: ios, range: NSRange(location: 0, length: ios.characters.count)) {
         if match.numberOfRanges == 3 {
-            let rangeKey = match.rangeAt(1)
-            let rangeValue = match.rangeAt(2)
+            let rangeKey = match.range(at: 1)
+            let rangeValue = match.range(at: 2)
             let key = ios[rangeKey]
             switch key {
             case "version":
@@ -174,9 +174,9 @@ func changeLanguageSupport(pathURL: URL) {
     
     let regex = try! NSRegularExpression(pattern: "\\| Swift 3\\.1 and above \\| (\\d\\.\\d) \\| \\[Download Version (\\d\\.\\d\\.\\d)\\]\\(([^\\)]*)\\) \\|")
     let match = regex.firstMatch(in: content, range: NSRange(location: 0, length: content.characters.count))!
-    let versionWithoutPatchRange = match.rangeAt(1)
-    let versionRange = match.rangeAt(2)
-    let downloadURLRange = match.rangeAt(3)
+    let versionWithoutPatchRange = match.range(at: 1)
+    let versionRange = match.range(at: 2)
+    let downloadURLRange = match.range(at: 3)
     
     content.replaceSubrange(versionWithoutPatchRange.rangeStringIndex(for: content), with: "\(versionTuple.major).\(versionTuple.minor)")
     content.replaceSubrange(versionRange.rangeStringIndex(for: content), with: version)


### PR DESCRIPTION
#### Description

MLIBZ-2111: bugfix transforms were being ignored when saving object using dynamic Realm

#### Changes

* `RealmCache.save()` using dynamic Realm was not considering cases where a transform needs to be applied

#### Tests

* New unit test added to test a scenario where a Date, which requires some transformation to JSON, is being saved to Realm