### PR TITLE
MLIBZ-2246: find by id must return entity not found error

### DIFF
--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -11,14 +11,21 @@ import Foundation
 /// Enum that contains all error types in the library.
 public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
     
-    /// Constant for 401 responses where the credentials are not enough to complete the request.
-    public static let InsufficientCredentials = "InsufficientCredentials"
-    
-    /// Constant for 401 responses where the credentials are not valid to complete the request.
-    public static let InvalidCredentials = "InvalidCredentials"
-    
-    /// Constant for 400 response where the number of results exceeded the limit.
-    public static let ResultSetSizeExceeded = "ResultSetSizeExceeded"
+    public enum Keys: String {
+        
+        /// Constant for 401 responses where the credentials are not enough to complete the request.
+        case insufficientCredentials = "InsufficientCredentials"
+        
+        /// Constant for 401 responses where the credentials are not valid to complete the request.
+        case invalidCredentials = "InvalidCredentials"
+        
+        /// Constant for 400 response where the number of results exceeded the limit.
+        case resultSetSizeExceeded = "ResultSetSizeExceeded"
+        
+        /// Constant for 404 response where the entity was not found in the collection
+        case entityNotFound = "EntityNotFound"
+        
+    }
     
     /// Error where Object ID is required.
     case objectIdMissing
@@ -74,6 +81,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     /// Error when the number of results exceeded the limit
     case resultSetSizeExceeded(debug: String, description: String)
     
+    case entityNotFound(debug: String, description: String)
+    
     /// Error localized description.
     public var description: String {
         let bundle = Bundle(for: Client.self)
@@ -86,7 +95,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .missingConfiguration(_, _, _, let description),
              .appNotFound(let description),
              .forbidden(let description),
-             .resultSetSizeExceeded(_, let description):
+             .resultSetSizeExceeded(_, let description),
+             .entityNotFound(_, let description):
             return description
         case .objectIdMissing:
             return NSLocalizedString("Error.objectIdMissing", bundle: bundle, comment: "")
@@ -123,7 +133,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .dataLinkEntityNotFound(_, _, let debug, _),
              .missingConfiguration(_, _, let debug, _),
              .unauthorized(_, _, _, let debug, _),
-             .resultSetSizeExceeded(let debug, _):
+             .resultSetSizeExceeded(let debug, _),
+             .entityNotFound(let debug, _):
             return debug
         default:
             return description

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -213,11 +213,19 @@ func buildError(
     } else if let response = response,
         response.isBadRequest,
         let json = json,
-        json["error"] == Error.ResultSetSizeExceeded,
+        json["error"] == Error.Keys.resultSetSizeExceeded.rawValue,
         let debug = json["debug"],
         let description = json["description"]
     {
         return Error.resultSetSizeExceeded(debug: debug, description: description)
+    } else if let response = response,
+        response.isNotFound,
+        let json = json,
+        json["error"] == Error.Keys.entityNotFound.rawValue,
+        let debug = json["debug"],
+        let description = json["description"]
+    {
+        return Error.entityNotFound(debug: debug, description: description)
     } else if let response = response,
         let json = client.responseParser.parse(data)
     {

--- a/Kinvey/Kinvey/PushOperation.swift
+++ b/Kinvey/Kinvey/PushOperation.swift
@@ -130,7 +130,7 @@ internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, [Swift.Erro
                             let debug = json["debug"],
                             let description = json["description"]
                         {
-                            if error == Error.InsufficientCredentials {
+                            if error == Error.Keys.insufficientCredentials.rawValue {
                                 self.sync?.removePendingOperation(pendingOperation)
                             }
                             let error = Error.unauthorized(

--- a/Kinvey/KinveyTests/AclTestCase.swift
+++ b/Kinvey/KinveyTests/AclTestCase.swift
@@ -59,7 +59,7 @@ class AclTestCase: StoreTestCase {
                 }
                 switch error {
                 case .unauthorized(_, _, let error, _, _):
-                    XCTAssertEqual(error, Kinvey.Error.InsufficientCredentials)
+                    XCTAssertEqual(error, Kinvey.Error.Keys.insufficientCredentials.rawValue)
                 default:
                     XCTFail()
                 }
@@ -166,7 +166,7 @@ class AclTestCase: StoreTestCase {
                     if let error = errors.first as? Kinvey.Error {
                         switch error {
                         case .unauthorized(_, _, let error, _, _):
-                            XCTAssertEqual(error, Kinvey.Error.InsufficientCredentials)
+                            XCTAssertEqual(error, Kinvey.Error.Keys.insufficientCredentials.rawValue)
                         default:
                             XCTFail()
                         }


### PR DESCRIPTION
#### Description

Find by `_id` must return `EntityNotFound` error

#### Changes

* Added one more case for the `Error` enum

#### Tests

* Unit test added to cover the situation when the entity was not found
