### PR TITLE
MLIBZ-2309: bugfix for the memory leak

### DIFF
--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -32,7 +32,7 @@ public protocol Persistable: Mappable {
     
 }
 
-struct AnyTransform: TransformType {
+class AnyTransform: TransformType {
     
     private let _transformFromJSON: (Any?) -> Any?
     private let _transformToJSON: (Any?) -> Any?
@@ -396,7 +396,7 @@ public func <- (left: List<BoolValue>, right: (String, Map)) {
 
 internal let KinveyMappingTypeKey = "Kinvey Mapping Type"
 
-struct PropertyMap: Sequence, IteratorProtocol, ExpressibleByDictionaryLiteral {
+class PropertyMap: Sequence, IteratorProtocol, ExpressibleByDictionaryLiteral {
     
     typealias Key = String
     typealias Value = (String, AnyTransform?)
@@ -406,7 +406,7 @@ struct PropertyMap: Sequence, IteratorProtocol, ExpressibleByDictionaryLiteral {
     private var keys = [Key]()
     private var currentIndex = 0
     
-    init(dictionaryLiteral elements: (Key, Value)...) {
+    required init(dictionaryLiteral elements: (Key, Value)...) {
         for (key, value) in elements {
             self[key] = value
         }
@@ -424,7 +424,7 @@ struct PropertyMap: Sequence, IteratorProtocol, ExpressibleByDictionaryLiteral {
         }
     }
     
-    mutating func next() -> Element? {
+    func next() -> Element? {
         if keys.startIndex <= currentIndex && currentIndex < keys.endIndex {
             let key = keys[currentIndex]
             if let value = map[key] {

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -56,7 +56,7 @@ internal func kinveyMappingType(left: String, right: String) {
     let currentThread = Thread.current
     if var kinveyMappingType = currentThread.threadDictionary[KinveyMappingTypeKey] as? [String : PropertyMap],
         let className = kinveyMappingType.first?.0,
-        var classMapping = kinveyMappingType[className]
+        let classMapping = kinveyMappingType[className]
     {
         classMapping[left] = (right, nil)
         kinveyMappingType[className] = classMapping
@@ -68,7 +68,7 @@ internal func kinveyMappingType<Transform: TransformType>(left: String, right: S
     let currentThread = Thread.current
     if var kinveyMappingType = currentThread.threadDictionary[KinveyMappingTypeKey] as? [String : PropertyMap],
         let className = kinveyMappingType.first?.0,
-        var classMapping = kinveyMappingType[className]
+        let classMapping = kinveyMappingType[className]
     {
         classMapping[left] = (right, AnyTransform(transform))
         kinveyMappingType[className] = classMapping


### PR DESCRIPTION
#### Description

Bugfix for the memory leak issue by changing a few structs to become classes since the Swift runtime allocation implementation is causing memory leaks in some cases

Here some simular cases around the `swift_slowAlloc` issue

https://bugs.swift.org/browse/SR-4518?jql=status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20text%20~%20%22swift_slowAlloc%22

#### Changes

* `AnyTransform` and `PropertyMap` are no longer structs, they are now classes

#### Tests

* No way to cover memory leaks using unit tests at this point