### PR TITLE
MLIBZ-2309: bugfix removing the usage o Thread.threadDictionary to avoid memory leaks

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -147,25 +147,32 @@ open class Entity: Object, Persistable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     public func mapping(map: Map) {
-        let originalThread = Thread.current
-        let runningMapping = originalThread.threadDictionary[KinveyMappingTypeKey] != nil
-        if runningMapping {
-            let operationQueue = OperationQueue()
-            operationQueue.name = "Kinvey Property Mapping"
-            operationQueue.maxConcurrentOperationCount = 1
-            operationQueue.addOperation {
-                let className = StringFromClass(cls: type(of: self))
-                Thread.current.threadDictionary[KinveyMappingTypeKey] = [className : PropertyMap()]
+        let className = StringFromClass(cls: type(of: self))
+        if kinveyProperyMapping[className] == nil {
+            currentMappingClass = className
+            mappingOperationQueue.addOperation {
+                if kinveyProperyMapping[className] == nil {
+                    kinveyProperyMapping[className] = PropertyMap()
+                }
                 self.propertyMapping(map)
-                originalThread.threadDictionary[KinveyMappingTypeKey] = Thread.current.threadDictionary[KinveyMappingTypeKey]
             }
-            operationQueue.waitUntilAllOperationsAreFinished()
+            mappingOperationQueue.waitUntilAllOperationsAreFinished()
+            currentMappingClass = nil
         } else {
             self.propertyMapping(map)
         }
     }
     
 }
+
+let mappingOperationQueue: OperationQueue = {
+    let operationQueue = OperationQueue()
+    operationQueue.name = "Kinvey Property Mapping"
+    operationQueue.maxConcurrentOperationCount = 1
+    return operationQueue
+}()
+var kinveyProperyMapping = [String : PropertyMap]()
+var currentMappingClass: String?
 
 /// Wrapper type for string values that needs to be stored locally in the device
 open class StringValue: Object, ExpressibleByStringLiteral {


### PR DESCRIPTION
#### Description

Bugfix removing the usage o `Thread.threadDictionary` to avoid memory leaks

#### Changes

- Object mapping runs in a `OperationQueue` and is not anymore storying the results into `Thread.threadDictionary` since memory leaks were happening because of the Swift bridge / runtime
- Few changes to the Travis CI script to be able to compile and run the unit tests

#### Tests

- Unit Test that measure the memory consumed in a long loop to make sure no memory is leaking
