### PR TITLE
MLIBZ-2210: handling user lockdown

### DIFF
--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -83,6 +83,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     
     case entityNotFound(debug: String, description: String)
     
+    case invalidCredentials(httpResponse: HTTPURLResponse?, data: Data?, debug: String, description: String)
+    
     /// Error localized description.
     public var description: String {
         let bundle = Bundle(for: Client.self)
@@ -96,7 +98,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .appNotFound(let description),
              .forbidden(let description),
              .resultSetSizeExceeded(_, let description),
-             .entityNotFound(_, let description):
+             .entityNotFound(_, let description),
+             .invalidCredentials(_, _, _, let description):
             return description
         case .objectIdMissing:
             return NSLocalizedString("Error.objectIdMissing", bundle: bundle, comment: "")
@@ -134,7 +137,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .missingConfiguration(_, _, let debug, _),
              .unauthorized(_, _, _, let debug, _),
              .resultSetSizeExceeded(let debug, _),
-             .entityNotFound(let debug, _):
+             .entityNotFound(let debug, _),
+             .invalidCredentials(_, _, let debug, _):
             return debug
         default:
             return description
@@ -149,7 +153,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .dataLinkEntityNotFound(let httpResponse, _, _, _),
              .methodNotAllowed(let httpResponse, _, _, _),
              .unauthorized(let httpResponse, _, _, _, _),
-             .invalidResponse(let httpResponse, _):
+             .invalidResponse(let httpResponse, _),
+             .invalidCredentials(let httpResponse, _, _, _):
             return httpResponse
         default:
             return nil
@@ -170,7 +175,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .methodNotAllowed(_, let data, _, _),
              .unauthorized(_, let data, _, _, _),
              .invalidResponse(_, let data),
-             .missingConfiguration(_, let data, _, _):
+             .missingConfiguration(_, let data, _, _),
+             .invalidCredentials(_, let data, _, _):
             return data
         default:
             return nil

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -423,6 +423,15 @@ internal class HttpRequest<Result>: TaskProgressRequest, Request {
                             self.credential = user
                             self.execute(urlSession: urlSession, completionHandler)
                         } else {
+                            if let error = error as? Kinvey.Error {
+                                switch error {
+                                case .invalidCredentials:
+                                    if let user = self.credential as? User {
+                                        user.logout()
+                                    }
+                                default: break
+                                }
+                            }
                             completionHandler?(data, HttpResponse(response: response), error)
                         }
                     }

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -149,13 +149,24 @@ func buildError(
         let debug = json["debug"],
         let description = json["description"]
     {
-        return Error.unauthorized(
-            httpResponse: response.httpResponse,
-            data: data,
-            error: error,
-            debug: debug,
-            description: description
-        )
+        client.activeUser?.logout()
+        switch error {
+        case Error.Keys.invalidCredentials.rawValue:
+            return Error.invalidCredentials(
+                httpResponse: response.httpResponse,
+                data: data,
+                debug: debug,
+                description: description
+            )
+        default:
+            return Error.unauthorized(
+                httpResponse: response.httpResponse,
+                data: data,
+                error: error,
+                debug: debug,
+                description: description
+            )
+        }
     } else if let response = response,
         response.isMethodNotAllowed,
         let json = json,

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -149,7 +149,10 @@ func buildError(
         let debug = json["debug"],
         let description = json["description"]
     {
-        client.activeUser?.logout()
+        let refreshToken = client.activeUser?.socialIdentity?.kinvey?["refresh_token"] as? String
+        if refreshToken == nil {
+            client.activeUser?.logout()
+        }
         switch error {
         case Error.Keys.invalidCredentials.rawValue:
             return Error.invalidCredentials(

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -386,17 +386,20 @@ class KinveyTestCase: XCTestCase {
         
     }
     
-    func signUp<UserType: User>(username: String? = nil, password: String? = nil, user: UserType? = nil, mustHaveAValidUserInTheEnd: Bool = true, client: Client? = nil, completionHandler: ((UserType?, Swift.Error?) -> Void)? = nil) {
+    func signUp<UserType: User>(username: String? = nil, password: String? = nil, user: UserType? = nil, mustIncludeSocialIdentity: Bool = false, mustHaveAValidUserInTheEnd: Bool = true, client: Client? = nil, completionHandler: ((UserType?, Swift.Error?) -> Void)? = nil) {
         let client = client ?? self.client
         if let user = client.activeUser {
             user.logout()
         }
         
+        let originalMustIncludeSocialIdentity = MockKinveyBackend.usersMustIncludeSocialIdentity
         if useMockData {
+            MockKinveyBackend.usersMustIncludeSocialIdentity = mustIncludeSocialIdentity
             setURLProtocol(MockKinveyBackend.self)
         }
         defer {
             if useMockData {
+                MockKinveyBackend.usersMustIncludeSocialIdentity = originalMustIncludeSocialIdentity
                 setURLProtocol(nil)
             }
         }

--- a/Kinvey/KinveyTests/MockKinveyBackend.swift
+++ b/Kinvey/KinveyTests/MockKinveyBackend.swift
@@ -16,6 +16,7 @@ class MockKinveyBackend: URLProtocol {
     static var baseURLBaas = URL(string: "https://baas.kinvey.com")!
     static var user = [String : [String : Any]]()
     static var appdata = [String : [[String : Any]]]()
+    static var usersMustIncludeSocialIdentity: Bool = false
     
     var requestJsonBody: [String : Any]? {
         if
@@ -132,6 +133,16 @@ class MockKinveyBackend: URLProtocol {
                                 user["_acl"] = [
                                     "creator" : "masterKey-creator-id"
                                 ]
+                                if MockKinveyBackend.usersMustIncludeSocialIdentity {
+                                    user["_socialIdentity"] = [
+                                        "kinveyAuth" : [
+                                            "access_token" : UUID().uuidString,
+                                            "token_type" : "Bearer",
+                                            "expires_in" : 59,
+                                            "refresh_token" : UUID().uuidString
+                                        ]
+                                    ]
+                                }
                                 MockKinveyBackend.user[userId] = user
                                 
                                 response(json: user)

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -2643,7 +2643,7 @@ class UserTests: KinveyTestCase {
                     client?.urlProtocolDidFinishLoading(self)
                 default:
                     type(of: self).invalidCredentialsCount += 1
-                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 4)
+                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 2)
                     let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
                     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
                     let json = [

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -2643,7 +2643,7 @@ class UserTests: KinveyTestCase {
                     client?.urlProtocolDidFinishLoading(self)
                 default:
                     type(of: self).invalidCredentialsCount += 1
-                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 2)
+                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 4)
                     let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
                     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
                     let json = [
@@ -4001,8 +4001,8 @@ extension UserTests {
         }
     }
     
-    func testUserLockDown() {
-        signUp()
+    func userLockDown(mustIncludeSocialIdentity: Bool) {
+        signUp(mustIncludeSocialIdentity: mustIncludeSocialIdentity)
         
         XCTAssertNotNil(Kinvey.sharedClient.activeUser)
         
@@ -4095,6 +4095,14 @@ extension UserTests {
         
         XCTAssertNil(Kinvey.sharedClient.activeUser)
         XCTAssertEqual(try? store.count().waitForResult().value(), 0)
+    }
+    
+    func testUserLockDown() {
+        userLockDown(mustIncludeSocialIdentity: false)
+    }
+    
+    func testUserLockDownWithRefreshToken() {
+        userLockDown(mustIncludeSocialIdentity: true)
     }
     
 }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -2643,7 +2643,7 @@ class UserTests: KinveyTestCase {
                     client?.urlProtocolDidFinishLoading(self)
                 default:
                     type(of: self).invalidCredentialsCount += 1
-                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 2)
+                    XCTAssertLessThanOrEqual(type(of: self).invalidCredentialsCount, 4)
                     let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
                     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
                     let json = [
@@ -3999,6 +3999,102 @@ extension UserTests {
         waitForExpectations(timeout: defaultTimeout) { error in
             expectationLogout = nil
         }
+    }
+    
+    func testUserLockDown() {
+        signUp()
+        
+        XCTAssertNotNil(Kinvey.sharedClient.activeUser)
+        
+        let store = DataStore<Person>.collection(.sync)
+        
+        do {
+            mockResponse(json: [
+                [
+                    "_id": UUID().uuidString,
+                    "name": "Victor",
+                    "age": 0,
+                    "_acl": [
+                        "creator": client.activeUser?.userId
+                    ],
+                    "_kmd": [
+                        "lmt": Date().toString(),
+                        "ect": Date().toString()
+                    ]
+                ]
+            ])
+            defer {
+                setURLProtocol(nil)
+            }
+            
+            weak var expectationLogout = expectation(description: "Sync")
+            
+            store.sync(options: nil) { (result: Result<(UInt, AnyRandomAccessCollection<Person>), [Swift.Error]>) in
+                switch result {
+                case .success(let count, let results):
+                    XCTAssertEqual(count, 0)
+                    XCTAssertEqual(results.count, 1)
+                case .failure(let errors):
+                    XCTFail(errors.first!.localizedDescription)
+                }
+                expectationLogout?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationLogout = nil
+            }
+        }
+        
+        XCTAssertNotNil(Kinvey.sharedClient.activeUser)
+        XCTAssertEqual(try? store.count().waitForResult().value(), 1)
+        
+        do {
+            mockResponse(
+                statusCode: 401,
+                json: [
+                    "error" : "InvalidCredentials",
+                    "description" : "Invalid credentials. Please retry your request with correct credentials",
+                    "debug" : "Authorization token invalid or expired"
+                ]
+            )
+            defer {
+                setURLProtocol(nil)
+            }
+            
+            weak var expectationLogout = expectation(description: "Sync")
+            
+            store.sync(options: nil) { (result: Result<(UInt, AnyRandomAccessCollection<Person>), [Swift.Error]>) in
+                switch result {
+                case .success:
+                    XCTFail()
+                case .failure(let errors):
+                    XCTAssertEqual(errors.count, 1)
+                    XCTAssertNotNil(errors.first as? Kinvey.Error)
+                    if let error = errors.first as? Kinvey.Error {
+                        switch error {
+                        case .invalidCredentials(let httpRequest, let data, let debug, let description):
+                            XCTAssertEqual(httpRequest?.statusCode, 401)
+                            XCTAssertNotNil(data)
+                            if let data = data {
+                                XCTAssertGreaterThan(data.count, 0)
+                            }
+                            XCTAssertEqual(debug, "Authorization token invalid or expired")
+                            XCTAssertEqual(description, "Invalid credentials. Please retry your request with correct credentials")
+                        default:
+                            XCTFail(error.description)
+                        }
+                    }
+                }
+                expectationLogout?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationLogout = nil
+            }
+        }
+        
+        XCTAssertNil(Kinvey.sharedClient.activeUser)
+        XCTAssertEqual(try? store.count().waitForResult().value(), 0)
     }
     
 }


### PR DESCRIPTION
#### Description

Handling a user lockdown case by automatically logout the user if a 401 response is returned from the server

#### Changes

- Checking if a 401 response is returned and then logout the user

#### Tests

- Unit test to mock the situation
