### PR TITLE
MLIBZ-2359: FileStore proper result types for sync wait calls

### DIFF
--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -112,7 +112,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         ttl: TTL? = nil,
         completionHandler: FileCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             image: image,
@@ -136,7 +136,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             image: image,
@@ -156,7 +156,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         options: Options? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let data = imageRepresentation.data(image: image)!
         file.mimeType = imageRepresentation.mimeType
         return upload(
@@ -177,7 +177,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         ttl: TTL? = nil,
         completionHandler: FileCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             image: image,
@@ -201,7 +201,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             image: image,
@@ -221,7 +221,7 @@ open class FileStore<FileType: File> {
         imageRepresentation: ImageRepresentation = .png,
         options: Options? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let data = imageRepresentation.data(image: image)!
         file.mimeType = imageRepresentation.mimeType
         return upload(
@@ -241,7 +241,7 @@ open class FileStore<FileType: File> {
         path: String,
         ttl: TTL? = nil,
         completionHandler: FileCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             path: path,
@@ -263,7 +263,7 @@ open class FileStore<FileType: File> {
         path: String,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             path: path,
@@ -281,7 +281,7 @@ open class FileStore<FileType: File> {
         path: String,
         options: Options? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             fromSource: .url(URL(fileURLWithPath: (path as NSString).expandingTildeInPath)),
@@ -297,7 +297,7 @@ open class FileStore<FileType: File> {
         stream: InputStream,
         ttl: TTL? = nil,
         completionHandler: FileCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             stream: stream,
@@ -319,7 +319,7 @@ open class FileStore<FileType: File> {
         stream: InputStream,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             stream: stream,
@@ -337,7 +337,7 @@ open class FileStore<FileType: File> {
         stream: InputStream,
         options: Options? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             fromSource: .stream(stream),
@@ -386,7 +386,7 @@ open class FileStore<FileType: File> {
         data: Data,
         ttl: TTL? = nil,
         completionHandler: FileCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             data: data,
@@ -408,7 +408,7 @@ open class FileStore<FileType: File> {
         data: Data,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             data: data,
@@ -426,7 +426,7 @@ open class FileStore<FileType: File> {
         data: Data,
         options: Options? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             fromSource: .data(data),
@@ -449,7 +449,7 @@ open class FileStore<FileType: File> {
         fromSource source: InputSource,
         ttl: TTL? = nil,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         return upload(
             file,
             fromSource: source,
@@ -735,7 +735,7 @@ open class FileStore<FileType: File> {
         fromSource source: InputSource,
         options: Options?,
         completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let requests = MultiRequest<Result<FileType, Swift.Error>>()
         requests.progress = Progress(totalUnitCount: 100)
         createBucket(
@@ -761,9 +761,13 @@ open class FileStore<FileType: File> {
             return promise
         }.then { file -> Void in
             requests.progress.completedUnitCount = requests.progress.totalUnitCount
-            completionHandler?(.success(file))
+            let result: Result<FileType, Swift.Error> = .success(file)
+            requests.result = result
+            completionHandler?(result)
         }.catch { error in
-            completionHandler?(.failure(error))
+            let result: Result<FileType, Swift.Error> = .failure(error)
+            requests.result = result
+            completionHandler?(result)
         }
         return AnyRequest(requests)
     }
@@ -931,7 +935,7 @@ open class FileStore<FileType: File> {
         storeType: StoreType = .cache,
         ttl: TTL? = nil,
         completionHandler: FilePathCompletionHandler? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<(FileType, URL), Swift.Error>> {
         return download(
             file,
             storeType: storeType,
@@ -953,7 +957,7 @@ open class FileStore<FileType: File> {
         storeType: StoreType = .cache,
         ttl: TTL? = nil,
         completionHandler: ((Result<(FileType, URL), Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<(FileType, URL), Swift.Error>> {
         return download(
             file,
             storeType: storeType,
@@ -971,7 +975,7 @@ open class FileStore<FileType: File> {
         storeType: StoreType = .cache,
         options: Options? = nil,
         completionHandler: ((Result<(FileType, URL), Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Any> {
+    ) -> AnyRequest<Result<(FileType, URL), Swift.Error>> {
         crashIfInvalid(file: file)
         
         if storeType == .sync || storeType == .cache,
@@ -1024,10 +1028,14 @@ open class FileStore<FileType: File> {
                         fulfill((file, localUrl))
                     }
                 }
-            }.then {
-                completionHandler?(.success($0))
-            }.catch { error in
-                completionHandler?(.failure(error))
+            }.then { (args) -> Void in
+                let result: Result<(FileType, URL), Swift.Error> = .success(args)
+                multiRequest.result = result
+                completionHandler?(result)
+            }.catch { (error) -> Void in
+                let result: Result<(FileType, URL), Swift.Error> = .failure(error)
+                multiRequest.result = result
+                completionHandler?(result)
             }
             return AnyRequest(multiRequest)
         } else {
@@ -1152,9 +1160,13 @@ open class FileStore<FileType: File> {
             }
         }.then { data -> Void in
             multiRequest.progress.completedUnitCount = multiRequest.progress.totalUnitCount
-            completionHandler?(.success((file, data)))
+            let result: Result<(FileType, Data), Swift.Error> = .success((file, data))
+            multiRequest.result = result
+            completionHandler?(result)
         }.catch { error in
-            completionHandler?(.failure(error))
+            let result: Result<(FileType, Data), Swift.Error> = .failure(error)
+            multiRequest.result = result
+            completionHandler?(result)
         }
         return AnyRequest(multiRequest)
     }

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -443,29 +443,12 @@ open class FileStore<FileType: File> {
         
     }
     
-    /// Uploads a file using a `NSData`.
-    fileprivate func upload(
-        _ file: FileType,
-        fromSource source: InputSource,
-        ttl: TTL? = nil,
-        completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<FileType, Swift.Error>> {
-        return upload(
-            file,
-            fromSource: source,
-            options: Options(
-                ttl: ttl
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
     @discardableResult
     open func create(
         _ file: FileType,
         data: Data,
         options: Options? = nil,
-        completionHandler: @escaping (Result<FileType, Swift.Error>) -> Void
+        completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let requests = MultiRequest<Result<FileType, Swift.Error>>()
         createBucket(
@@ -473,10 +456,14 @@ open class FileStore<FileType: File> {
             fromSource: .data(data),
             options: options,
             requests: requests
-        ).then { file, skip in
-            completionHandler(.success(file))
+        ).then { (file, skip) -> Void in
+            let result: Result<FileType, Swift.Error> = .success(file)
+            requests.result = result
+            completionHandler?(result)
         }.catch {
-            completionHandler(.failure($0))
+            let result: Result<FileType, Swift.Error> = .failure($0)
+            requests.result = result
+            completionHandler?(result)
         }
         return AnyRequest(requests)
     }
@@ -486,7 +473,7 @@ open class FileStore<FileType: File> {
         _ file: FileType,
         path: String,
         options: Options? = nil,
-        completionHandler: @escaping (Result<FileType, Swift.Error>) -> Void
+        completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let requests = MultiRequest<Result<FileType, Swift.Error>>()
         createBucket(
@@ -494,10 +481,14 @@ open class FileStore<FileType: File> {
             fromSource: .url(URL(fileURLWithPath: (path as NSString).expandingTildeInPath)),
             options: options,
             requests: requests
-        ).then { file, skip in
-            completionHandler(.success(file))
+        ).then { (file, skip) -> Void in
+            let result: Result<FileType, Swift.Error> = .success(file)
+            requests.result = result
+            completionHandler?(result)
         }.catch {
-            completionHandler(.failure($0))
+            let result: Result<FileType, Swift.Error> = .failure($0)
+            requests.result = result
+            completionHandler?(result)
         }
         return AnyRequest(requests)
     }
@@ -507,7 +498,7 @@ open class FileStore<FileType: File> {
         _ file: FileType,
         stream: InputStream,
         options: Options? = nil,
-        completionHandler: @escaping (Result<FileType, Swift.Error>) -> Void
+        completionHandler: ((Result<FileType, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<FileType, Swift.Error>> {
         let requests = MultiRequest<Result<FileType, Swift.Error>>()
         createBucket(
@@ -515,10 +506,14 @@ open class FileStore<FileType: File> {
             fromSource: .stream(stream),
             options: options,
             requests: requests
-        ).then { file, skip in
-            completionHandler(.success(file))
+        ).then { (file, skip) -> Void in
+            let result: Result<FileType, Swift.Error> = .success(file)
+            requests.result = result
+            completionHandler?(result)
         }.catch {
-            completionHandler(.failure($0))
+            let result: Result<FileType, Swift.Error> = .failure($0)
+            requests.result = result
+            completionHandler?(result)
         }
         return AnyRequest(requests)
     }

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -96,8 +96,8 @@ open class User: NSObject, Credential, Mappable {
         )
     }
     
-    private class func login<U: User, ResultType>(
-        request: HttpRequest<ResultType>,
+    private class func login<U: User>(
+        request: HttpRequest<Result<U, Swift.Error>>,
         client: Client,
         userType: U.Type,
         completionHandler: ((Result<U, Swift.Error>) -> Void)?
@@ -114,10 +114,14 @@ open class User: NSObject, Credential, Mappable {
                     reject(buildError(data, response, error, client))
                 }
             }
-        }.then { user in
-            completionHandler?(.success(user))
+        }.then { (user) -> Void in
+            let result: Result<U, Swift.Error> = .success(user)
+            request.result = result
+            completionHandler?(result)
         }.catch { error in
-            completionHandler?(.failure(error))
+            let result: Result<U, Swift.Error> = .failure(error)
+            request.result = result
+            completionHandler?(result)
         }
     }
     

--- a/Kinvey/KinveyTests/FileTestCase.swift
+++ b/Kinvey/KinveyTests/FileTestCase.swift
@@ -264,7 +264,7 @@ class FileTestCase: StoreTestCase {
         
         weak var expectationDownload = expectation(description: "Download")
         
-        fileStore.download(file) { (file, url: URL?, error) in
+        let request = fileStore.download(file) { (file, url: URL?, error) in
             XCTAssertTrue(Thread.isMainThread)
             
             XCTAssertNil(file)
@@ -277,6 +277,16 @@ class FileTestCase: StoreTestCase {
         
         waitForExpectations(timeout: defaultTimeout) { error in
             expectationDownload = nil
+        }
+        
+        XCTAssertNotNil(request.result)
+        if let result = request.result {
+            do {
+                let _ = try result.value()
+                XCTFail()
+            } catch {
+                XCTAssertTimeoutError(error)
+            }
         }
     }
     
@@ -1060,7 +1070,7 @@ class FileTestCase: StoreTestCase {
         }
     }
     
-    func testUploadUIImagePNG() {
+    func testUploadImagePNG() {
         signUp()
         
         var file = File() {
@@ -1238,6 +1248,14 @@ class FileTestCase: StoreTestCase {
             waitForExpectations(timeout: defaultTimeout) { error in
                 expectationUpload = nil
             }
+            
+            XCTAssertNotNil(request.result)
+            if let result = request.result {
+                let file = try? result.value()
+                XCTAssertNotNil(file?.download)
+                XCTAssertNotNil(file?.downloadURL)
+                XCTAssertEqual(file?.mimeType, "image/png")
+            }
         }
         
         if !useMockData {
@@ -1279,7 +1297,7 @@ class FileTestCase: StoreTestCase {
         }
     }
     
-    func testUploadUIImageJPEG() {
+    func testUploadImageJPEG() {
         signUp()
         
         var file = File() {
@@ -1455,6 +1473,14 @@ class FileTestCase: StoreTestCase {
             
             waitForExpectations(timeout: defaultTimeout) { error in
                 expectationUpload = nil
+            }
+            
+            XCTAssertNotNil(request.result)
+            if let result = request.result {
+                let file = try? result.value()
+                XCTAssertNotNil(file?.download)
+                XCTAssertNotNil(file?.downloadURL)
+                XCTAssertEqual(file?.mimeType, "image/jpeg")
             }
         }
         
@@ -1773,7 +1799,7 @@ class FileTestCase: StoreTestCase {
         do {
             weak var expectationDownload = expectation(description: "Download")
             
-            fileStore.download(self.myFile!) { (file, data: Data?, error) in
+            let request = fileStore.download(self.myFile!) { (file, data: Data?, error) in
                 XCTAssertNotNil(file)
                 XCTAssertNotNil(data)
                 XCTAssertNil(error)
@@ -1791,6 +1817,17 @@ class FileTestCase: StoreTestCase {
             
             waitForExpectations(timeout: defaultTimeout) { error in
                 expectationDownload = nil
+            }
+            
+            XCTAssertNotNil(request.result)
+            if let result = request.result {
+                do {
+                    let (file, data) = try result.value()
+                    XCTAssertEqual(file.label, "trailer")
+                    XCTAssertEqual(UInt64(data.count), self.caminandes3TrailerFileSize)
+                } catch {
+                    XCTFail(error.localizedDescription)
+                }
             }
         }
     }


### PR DESCRIPTION
#### Description

FileStore proper result types for sync wait calls

#### Changes

- Setting the result for each request returned

#### Tests

- Made some additions to existing unit tests
