### PR TITLE
MLIBZ-2400: Changing the default MIC Version to v3

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -130,7 +130,7 @@ open class Client: Credential {
     open var logNetworkEnabled = false
     
     /// Stores the MIC API Version to be used in MIC calls 
-    open var micApiVersion: MICApiVersion? = .v1
+    open var micApiVersion: MICApiVersion? = .v3
     
     /// Default constructor. The `initialize` method still need to be called after instanciate a new instance.
     public init() {

--- a/Kinvey/KinveyTests/ClientTestCase.swift
+++ b/Kinvey/KinveyTests/ClientTestCase.swift
@@ -133,4 +133,8 @@ class ClientTestCase: KinveyTestCase {
         }.to(throwAssertion())
     }
     
+    func testDefaultMICVersion() {
+        XCTAssertEqual(Client().micApiVersion, .v3)
+    }
+    
 }


### PR DESCRIPTION
#### Description

Changing the default MIC Version to v3

#### Changes

- The default value for `Client.micApiVersion` is now `.v3`

#### Tests

- We already have unit tests for that
