### PR TITLE
MLIBZ-1568: adding Swift version to User-Agent HTTP header

### DIFF
--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -126,7 +126,7 @@ enum HttpHeader {
             case .requestId(let requestId):
                 return requestId
             case .userAgent:
-                return "Kinvey SDK \(Bundle(for: Client.self).infoDictionary!["CFBundleShortVersionString"]!)"
+                return "Kinvey SDK \(Bundle(for: Client.self).infoDictionary!["CFBundleShortVersionString"]!) (Swift \(swiftVersion))"
             case .deviceInfo:
                 #if os(iOS) || os(tvOS)
                     let device = UIDevice.current

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -117,6 +117,30 @@ public var logLevel: LogLevel = log.outputLevel.logLevel {
 public let defaultTag = "kinvey"
 let groupId = "_group_"
 
+#if swift(>=5)
+    let swiftVersion = "5 or above"
+#elseif swift(>=4.0.3)
+    let swiftVersion = "4.0.3"
+#elseif swift(>=4.0.2)
+    let swiftVersion = "4.0.2"
+#elseif swift(>=4.0)
+    let swiftVersion = "4.0"
+#elseif swift(>=3.1.1)
+    let swiftVersion = "3.1.1"
+#elseif swift(>=3.1)
+    let swiftVersion = "3.1"
+#elseif swift(>=3.0.2)
+    let swiftVersion = "3.0.2"
+#elseif swift(>=3.0.1)
+    let swiftVersion = "3.0.1"
+#elseif swift(>=3.0)
+    let swiftVersion = "3.0"
+#elseif swift(>=2.2.1)
+    let swiftVersion = "2.2.1"
+#elseif swift(>=2.2)
+    let swiftVersion = "2.2"
+#endif
+
 #if os(macOS)
     let cacheBasePath = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!).appendingPathComponent(Bundle.main.bundleIdentifier!).path
 #else

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -1853,7 +1853,11 @@ class NetworkStoreTests: StoreTestCase {
                 XCTAssertEqual(textCheckingResults.count, 1)
                 if let textCheckingResult = textCheckingResults.first {
                     let device = deviceInfo.substring(with: textCheckingResult.range(at: 1))
-                    XCTAssertEqual(device, "iPhone")
+                    #if os(macOS)
+                        XCTAssertEqual(device, "OSX")
+                    #elseif os(iOS)
+                        XCTAssertEqual(device, "iPhone")
+                    #endif
                 }
             }
             


### PR DESCRIPTION
#### Description

Adding Swift version to User-Agent HTTP header

#### Changes

- Changing all HTTP requests to add the Swift version in the `User-Agent` header

#### Tests

- Unit test changed to check if the Swift version is present
