### PR TITLE
MLIBZ-2210: removing compiler warning for Client.timeout

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -91,7 +91,17 @@ open class Client: Credential {
     
     /// Timeout interval for this client instance.
     @available(*, deprecated: 3.12.2, message: "Please use `options` instead")
-    open var timeoutInterval: TimeInterval = 60
+    open var timeoutInterval: TimeInterval {
+        get {
+            return options?.timeout ?? Client.urlSessionConfiguration.timeoutIntervalForRequest
+        }
+        set {
+            if options == nil {
+                options = Options()
+            }
+            options?.timeout = newValue
+        }
+    }
     
     /**
      Hold default optional values for all calls made by this `Client` instance
@@ -340,9 +350,6 @@ open class Client: Credential {
         self.encryptionKey = encryptionKey
         self.schemaVersion = schema?.version ?? 0
         self.options = options
-        if let timeout = options?.timeout {
-            self.timeoutInterval = timeout
-        }
         
         Migration.performMigration(persistenceId: appKey, encryptionKey: encryptionKey, schemaVersion: schemaVersion, migrationHandler: schema?.migrationHandler)
         

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -344,7 +344,9 @@ internal class HttpRequest<Result>: TaskProgressRequest, Request {
         let url = endpoint.url
         request = URLRequest(url: url)
         request.httpMethod = httpMethod.stringValue
-        request.timeoutInterval = options?.timeout ?? client.options?.timeout ?? client.timeoutInterval
+        if let timeout = options?.timeout ?? client.options?.timeout {
+            request.timeoutInterval = timeout
+        }
         if let body = body {
             body.attachTo(request: &request)
         }


### PR DESCRIPTION
#### Description

Removing compiler warning for `Client.timeout`

#### Changes

- `Client.timeout` is now a shortcut for `Client.options.timeout`

#### Tests

- Unit tests already cover the changes
