### PR TITLE
MLIBZ-2408: Removing DataStore Cache instances

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -35,7 +35,6 @@ open class Client: Credential {
                 if let sharedKeychain = sharedKeychain {
                     try! sharedKeychain.removeAll()
                 }
-                dataStoreInstances.removeAll()
             } else {
                 if let sharedKeychain = sharedKeychain {
                     try! sharedKeychain.removeAll()
@@ -133,8 +132,6 @@ open class Client: Credential {
     
     ///Default Value for DataStore tag
     open static let defaultTag = Kinvey.defaultTag
-    
-    var dataStoreInstances = [DataStoreTypeTag : AnyObject]()
     
     /// Enables logging for any network calls.
     open var logNetworkEnabled = false

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -9,40 +9,12 @@
 import Foundation
 import PromiseKit
 
-class DataStoreTypeTag: Hashable {
-    
-    let persistableType: Persistable.Type
-    let tag: String
-    let type: StoreType
-    
-    init(persistableType: Persistable.Type, tag: String, type: StoreType) {
-        self.persistableType = persistableType
-        self.tag = tag
-        self.type = type
-    }
-    
-    var hashValue: Int {
-        var hash = NSDecimalNumber(value: 5)
-        hash = 23 * hash + NSDecimalNumber(value: NSStringFromClass(persistableType as! AnyClass).hashValue)
-        hash = 23 * hash + NSDecimalNumber(value: tag.hashValue)
-        hash = 23 * hash + NSDecimalNumber(value: type.hashValue)
-        return hash.hashValue
-    }
-    
-}
-
 func +(lhs: NSDecimalNumber, rhs: NSDecimalNumber) -> NSDecimalNumber {
     return lhs.adding(rhs)
 }
 
 func *(lhs: NSDecimalNumber, rhs: NSDecimalNumber) -> NSDecimalNumber {
     return lhs.multiplying(by: rhs)
-}
-
-func ==(lhs: DataStoreTypeTag, rhs: DataStoreTypeTag) -> Bool {
-    return lhs.persistableType == rhs.persistableType &&
-        lhs.tag == rhs.tag &&
-        lhs.type == rhs.type
 }
 
 /// Class to interact with a specific collection in the backend.
@@ -136,22 +108,16 @@ open class DataStore<T: Persistable> where T: NSObject {
         if !client.isInitialized() {
             fatalError("Client is not initialized. Call Kinvey.sharedClient.initialize(...) to initialize the client before creating a DataStore.")
         }
-        let key = DataStoreTypeTag(persistableType: T.self, tag: tag, type: type)
-        var dataStore = client.dataStoreInstances[key] as? DataStore
-        if dataStore == nil {
-            let fileURL = client.fileURL(tag)
-            dataStore = DataStore<T>(
-                type: type,
-                deltaSet: deltaSet ?? false,
-                autoPagination: autoPagination,
-                client: client,
-                fileURL: fileURL,
-                encryptionKey: client.encryptionKey,
-                validationStrategy: validationStrategy
-            )
-            client.dataStoreInstances[key] = dataStore
-        }
-        return dataStore!
+        let fileURL = client.fileURL(tag)
+        return DataStore<T>(
+            type: type,
+            deltaSet: deltaSet ?? false,
+            autoPagination: autoPagination,
+            client: client,
+            fileURL: fileURL,
+            encryptionKey: client.encryptionKey,
+            validationStrategy: validationStrategy
+        )
     }
     
     /**

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -45,7 +45,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     internal let cache: AnyCache<T>?
     internal let sync: AnySync?
     
-    fileprivate var deltaSet: Bool
+    open fileprivate(set) var deltaSet: Bool
     
     fileprivate let uuid = UUID()
     

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -3243,6 +3243,10 @@ class NetworkStoreTests: StoreTestCase {
         let ds2 = DataStore<Person>.collection(.network, deltaSet: false)
         XCTAssertTrue(ds1.deltaSet)
         XCTAssertFalse(ds2.deltaSet)
+        
+        let addr1 = Unmanaged.passUnretained(ds1).toOpaque()
+        let addr2 = Unmanaged.passUnretained(ds2).toOpaque()
+        XCTAssertNotEqual(addr1, addr2)
     }
     
 }

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -3238,6 +3238,13 @@ class NetworkStoreTests: StoreTestCase {
         }
     }
     
+    func testDataStoreCacheInstances() {
+        let ds1 = DataStore<Person>.collection(.network, deltaSet: true)
+        let ds2 = DataStore<Person>.collection(.network, deltaSet: false)
+        XCTAssertTrue(ds1.deltaSet)
+        XCTAssertFalse(ds2.deltaSet)
+    }
+    
 }
 
 class Products: Entity {


### PR DESCRIPTION
#### Description

Removing Cache for DataStore instances, since there's no need for them and could cause trouble if you have multiple configurations for the same DataStore

#### Changes

- `Client` does not cache instances of DataStores anymore

#### Tests

- TBD
