### PR TITLE
MLIBZ-2409: removeAll() request

### DIFF
--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -378,6 +378,8 @@ class HttpRequestFactory: RequestFactory {
         options: Options?,
         resultType: Result.Type
     ) -> HttpRequest<Result> {
+        let query = Query(query)
+        query.emptyPredicateMustReturnNil = false
         let request = HttpRequest<Result>(
             httpMethod: .delete,
             endpoint: Endpoint.appDataByQuery(client: client, collectionName: collectionName, query: query),

--- a/Kinvey/Kinvey/Query.swift
+++ b/Kinvey/Kinvey/Query.swift
@@ -50,6 +50,8 @@ public final class Query: NSObject, BuilderType, Mappable {
     /// Impose a limit of records in the results of the query.
     open var limit: Int?
     
+    internal var emptyPredicateMustReturnNil = true
+    
     public override var description: String {
         return "Fields: \(String(describing: fields))\nPredicate: \(String(describing: predicate))\nSort Descriptors: \(String(describing: sortDescriptors))\nSkip: \(String(describing: skip))\nLimit: \(String(describing: limit))"
     }
@@ -133,7 +135,7 @@ public final class Query: NSObject, BuilderType, Mappable {
     
     fileprivate var queryStringEncoded: String? {
         guard let predicate = predicate else {
-            return nil
+            return emptyPredicateMustReturnNil ? nil : "{}"
         }
         
         let translatedPredicate = translate(predicate: predicate)


### PR DESCRIPTION
#### Description

`removeAll()` must generate a request like `/appdata/kid/collection?query={}` instead of only `/appdata/kid/collection`

#### Changes

- Be able to force a `query` param when is needed

#### Tests

- Unit Test added to cover the use case
