### PR TITLE
MLIBZ-2099: thread safe reference observe

### DIFF
--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -2272,6 +2272,10 @@ open class DataStore<T: Persistable> where T: NSObject {
         }
         return AnyRequest(request)
     }
+    
+    public func observe(_ query: Query? = nil, completionHandler: @escaping (CollectionChange<AnyRandomAccessCollection<T>>) -> Void) -> AnyNotificationToken? {
+        return cache?.observe(query, completionHandler: completionHandler)
+    }
 
 }
 

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -39,6 +39,14 @@ internal func StringFromClass(cls: AnyClass) -> String {
     return className
 }
 
+public enum ObjectChange<T: Entity> {
+    
+    case change(T)
+    case deleted
+    case error(Swift.Error)
+    
+}
+
 /// Base class for entity classes that are mapped to a collection in Kinvey.
 open class Entity: Object, Persistable {
     
@@ -81,6 +89,9 @@ open class Entity: Object, Persistable {
     /// The `_acl` property mapped in the Kinvey backend.
     @objc
     public dynamic var acl: Acl?
+    
+    internal var realmConfiguration: Realm.Configuration?
+    internal var reference: ThreadSafeReference<Entity>?
     
     /// Default Constructor.
     public required init() {

--- a/Kinvey/KinveyTests/MemoryCache.swift
+++ b/Kinvey/KinveyTests/MemoryCache.swift
@@ -115,4 +115,8 @@ class MemoryCache<T: Persistable>: Cache<T>, CacheType where T: NSObject {
         return []
     }
     
+    func observe(_ query: Query?, completionHandler: @escaping (CollectionChange<AnyRandomAccessCollection<Type>>) -> Void) -> AnyNotificationToken {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Kinvey
 import Nimble
+import RealmSwift
 
 class SyncStoreTests: StoreTestCase {
     
@@ -2845,6 +2846,115 @@ class SyncStoreTests: StoreTestCase {
         
         waitForExpectations(timeout: defaultTimeout * (Double(size) / 10_000.0)) { error in
             expectationPull = nil
+        }
+    }
+    
+    func testObjectObserve() {
+        let dataStore = DataStore<Person>.collection(.sync)
+        
+        let personId = UUID().uuidString
+        
+        let person = Person()
+        person.personId = personId
+        person.name = "Victor"
+        XCTAssertNil(person.realm)
+        XCTAssertNil(person.realmConfiguration)
+        XCTAssertNil(person.reference)
+        
+        let person2 = try! dataStore.save(person, options: nil).waitForResult(timeout: defaultTimeout).value()
+        XCTAssertNil(person2.realm)
+        XCTAssertNotNil(person2.realmConfiguration)
+        XCTAssertNotNil(person2.reference)
+        
+        var notified = false
+        
+        weak var expectationObserve = expectation(description: "Observe")
+        
+        let notificationToken = person2.observe { (objectChange: Kinvey.ObjectChange<Person>) in
+            notified = true
+            switch objectChange {
+            case .change(let person):
+                XCTAssertEqual(person.name, "Victor Barros")
+            case .deleted:
+                XCTFail()
+            case .error(let error):
+                XCTFail(error.localizedDescription)
+            }
+            expectationObserve?.fulfill()
+        }
+        
+        let realm = try! Realm(configuration: person2.realmConfiguration!)
+        let person3 = Person()
+        person3.personId = personId
+        person3.name = "Victor Barros"
+        try! realm.write {
+            realm.add(person3, update: true)
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            notificationToken?.invalidate()
+            expectationObserve = nil
+        }
+        
+        XCTAssertTrue(notified)
+        
+        XCTAssertEqual(person.name, "Victor Barros")
+        XCTAssertEqual(person2.name, "Victor Barros")
+    }
+    
+    func testCollectionObserve() {
+        let dataStore = DataStore<Person>.collection(.sync)
+        
+        let personId = UUID().uuidString
+        let personName = "Victor"
+        
+        var count = 0
+        weak var expectationObserveInitial = expectation(description: "Observe Initial")
+        weak var expectationObserveUpdate = expectation(description: "Observe Update")
+        
+        let notificationToken = dataStore.observe {
+            defer {
+                count += 1
+            }
+            switch $0 {
+            case .initial(let results):
+                XCTAssertEqual(count, 0)
+                XCTAssertEqual(results.count, 0)
+                expectationObserveInitial?.fulfill()
+            case .update(let results, let deletions, let insertions, let modifications):
+                XCTAssertEqual(count, 1)
+                XCTAssertEqual(results.count, 1)
+                XCTAssertNotNil(results.first)
+                if let person = results.first {
+                    XCTAssertEqual(person.personId, personId)
+                    XCTAssertEqual(person.name, personName)
+                }
+                XCTAssertEqual(deletions.count, 0)
+                XCTAssertEqual(insertions.count, 1)
+                XCTAssertEqual(insertions.first, 0)
+                XCTAssertEqual(modifications.count, 0)
+                expectationObserveUpdate?.fulfill()
+            case .error(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        
+        let person = Person()
+        person.personId = personId
+        person.name = personName
+        XCTAssertNil(person.realm)
+        XCTAssertNil(person.realmConfiguration)
+        XCTAssertNil(person.reference)
+        
+        let person2 = try! dataStore.save(person, options: nil).waitForResult(timeout: defaultTimeout).value()
+        XCTAssertNil(person2.realm)
+        XCTAssertNotNil(person2.realmConfiguration)
+        XCTAssertNotNil(person2.reference)
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            notificationToken?.invalidate()
+            expectationObserveInitial = nil
+            expectationObserveUpdate = nil
         }
     }
     


### PR DESCRIPTION
#### Description

Using the `ThreadSafeReference` from `Realm` to allow detached objects observe for changes

#### Changes

- Observe for changes in the local cache either by `query` or `object`
- Some wrappers added to allow future different implementations

#### Tests

- Unit tests to observe `objects` and `queries`
