### PR TITLE
MLIBZ-2402: authServiceID using a BasicAuth credential

### DIFF
--- a/Kinvey/Kinvey/Credential.swift
+++ b/Kinvey/Kinvey/Credential.swift
@@ -15,3 +15,15 @@ public protocol Credential {
     var authorizationHeader: String? { get }
 
 }
+
+struct BasicAuthCredential: Credential {
+    
+    let username: String
+    let password: String
+    
+    var authorizationHeader: String? {
+        let token = "\(username):\(password)".data(using: .utf8)?.base64EncodedString() ?? ""
+        return "Basic \(token)"
+    }
+    
+}

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -578,10 +578,23 @@ class HttpRequestFactory: RequestFactory {
             "code" : code
         ]
         set(&params, clientId: options?.authServiceId)
+        let client = options?.client ?? self.client
+        var credential: Credential
+        if let authServiceId = options?.authServiceId,
+            let appKey = client.appKey,
+            let appSecret = client.appSecret
+        {
+            credential = BasicAuthCredential(
+                username: "\(appKey).\(authServiceId)",
+                password: appSecret
+            )
+        } else {
+            credential = client
+        }
         let request = HttpRequest<Any>(
             httpMethod: .post,
             endpoint: Endpoint.oauthToken(client: client),
-            credential: client,
+            credential: credential,
             body: Body.formUrlEncoded(params: params),
             options: options
         )
@@ -646,10 +659,23 @@ class HttpRequestFactory: RequestFactory {
             "refresh_token" : refreshToken
         ]
         set(&params, clientId: options?.authServiceId)
+        let client = options?.client ?? self.client
+        var credential: Credential
+        if let authServiceId = options?.authServiceId,
+            let appKey = client.appKey,
+            let appSecret = client.appSecret
+        {
+            credential = BasicAuthCredential(
+                username: "\(appKey).\(authServiceId)",
+                password: appSecret
+            )
+        } else {
+            credential = client
+        }
         let request = HttpRequest<Any>(
             httpMethod: .post,
             endpoint: Endpoint.oauthToken(client: client),
-            credential: client,
+            credential: credential,
             body: Body.formUrlEncoded(params: params),
             options: options
         )

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -4409,9 +4409,6 @@ extension UserTests {
         userLockDown(mustIncludeSocialIdentity: true)
     }
     
-    func testAuthServiceId() {
-    }
-    
 }
 
 #endif

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -2359,6 +2359,7 @@ class UserTests: KinveyTestCase {
                     client?.urlProtocol(self, didLoad: data)
                     client?.urlProtocolDidFinishLoading(self)
                 case 2:
+                    XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], Kinvey.sharedClient.authorizationHeader)
                     switch Body.buildFormUrlEncoded(body: request.httpBodyString) {
                     case .formUrlEncoded(let params):
                         XCTAssertEqual(params, [
@@ -2501,6 +2502,231 @@ class UserTests: KinveyTestCase {
             redirectURI: redirectURI,
             username: "custom",
             password: "1234"
+        ) { user, error in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+        
+        XCTAssertNotNil(client.activeUser)
+        
+        do {
+            let store = DataStore<Person>.collection(.network)
+            
+            weak var expectationFind = expectation(description: "Find")
+            
+            store.find { persons, error in
+                XCTAssertNotNil(persons)
+                XCTAssertNil(error)
+                
+                expectationFind?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { (error) in
+                expectationFind = nil
+            }
+        }
+    }
+    
+    func testMICLoginAutomatedAuthorizationGrantFlowWithAuthServiceID() {
+        if let user = client.activeUser {
+            user.logout()
+        }
+        defer {
+            if let user = client.activeUser {
+                user.logout()
+            }
+        }
+        
+        class MICLoginAutomatedAuthorizationGrantFlowURLProtocol: URLProtocol {
+        
+            static let authServiceId = UUID().uuidString
+            static let code = "7af647ad1414986bec71d7799ced85fd271050a8"
+            static let tempLoginUri = "https://auth.kinvey.com/oauth/authenticate/b3ca941c1141468bb19d2f2c7409f7a6"
+            lazy var code: String = MICLoginAutomatedAuthorizationGrantFlowURLProtocol.code
+            lazy var tempLoginUri: String = MICLoginAutomatedAuthorizationGrantFlowURLProtocol.tempLoginUri
+            static var count = 0
+            
+            override class func canInit(with request: URLRequest) -> Bool {
+                return true
+            }
+            
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+                return request
+            }
+            
+            override func startLoading() {
+                switch type(of: self).count {
+                case 0:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "temp_login_uri" : tempLoginUri
+                    ]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 1:
+                    XCTAssertEqual(request.url!.absoluteString, tempLoginUri)
+                    let redirectRequest = URLRequest(url: URL(string: "micauthgrantflow://?code=\(code)")!)
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: ["Location" : redirectRequest.url!.absoluteString])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    client?.urlProtocol(self, wasRedirectedTo: redirectRequest, redirectResponse: response)
+                    let data = "Found. Redirecting to micauthgrantflow://?code=\(code)".data(using: String.Encoding.utf8)!
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 2:
+                    XCTAssertNotEqual(request.allHTTPHeaderFields?["Authorization"], Kinvey.sharedClient.authorizationHeader)
+                    let token = "\(Kinvey.sharedClient.appKey!).\(MICLoginAutomatedAuthorizationGrantFlowURLProtocol.authServiceId):\(Kinvey.sharedClient.appSecret!)".data(using: String.Encoding.utf8)?.base64EncodedString()
+                    XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Basic \(token!)")
+                    switch Body.buildFormUrlEncoded(body: request.httpBodyString) {
+                    case .formUrlEncoded(let params):
+                        XCTAssertEqual(params, [
+                            "client_id" : "\(MockKinveyBackend.kid).\(MICLoginAutomatedAuthorizationGrantFlowURLProtocol.authServiceId)",
+                            "code" : code,
+                            "redirect_uri" : "micAuthGrantFlow%3A%2F%2F",
+                            "grant_type" : "authorization_code"
+                        ])
+                    default:
+                        XCTFail()
+                    }
+                    
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "access_token" : "7f3fe7847a7292994c87fa322405cb8e03b7bf9c",
+                        "token_type" : "bearer",
+                        "expires_in" : 3599,
+                        "refresh_token" : "dc6118e98b8c004a6e2d3e2aa985f57e40a87a02"
+                    ] as [String : Any]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 3:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "error" : "UserNotFound",
+                        "description" : "This user does not exist for this app backend",
+                        "debug" : ""
+                    ]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 4:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "_socialIdentity" : [
+                            "kinveyAuth": [
+                                "access_token" : "a10a3743028e2e92b97037825b50a2666608b874",
+                                "refresh_token" : "627b034f5ec409899252a8017cb710566dfd2620",
+                                "id" : "custom",
+                                "audience" : MockKinveyBackend.kid
+                            ]
+                        ],
+                        "username" : "3b788b0c-cb99-4692-b3ae-a6b10b3d76f2",
+                        "password" : "fa0f771f-6480-4f11-a11b-dc85cce52beb",
+                        "_kmd" : [
+                            "lmt" : "2016-09-01T01:48:01.177Z",
+                            "ect" : "2016-09-01T01:48:01.177Z",
+                            "authtoken" : "12ed2b41-a5a1-4f37-a640-3a9c62c3fefd.rUHKOlQuRb4pW4NjmCimJ64rd2BF3drXy1SjHtuVCoM="
+                        ],
+                        "_id" : "57c788d168d976c525ee4602",
+                        "_acl" : [
+                            "creator" : "57c788d168d976c525ee4602"
+                        ]
+                    ] as [String : Any]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 5:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "error" : "InvalidCredentials",
+                        "description" : "Invalid credentials. Please retry your request with correct credentials",
+                        "debug" : "Error encountered authenticating against kinveyAuth: {\"error\":\"server_error\",\"error_description\":\"Access Token not found\"}"
+                    ]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 6:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "access_token" : "7f3fe7847a7292994c87fa322405cb8e03b7bf9c",
+                        "token_type" : "bearer",
+                        "expires_in" : 3599,
+                        "refresh_token" : "dc6118e98b8c004a6e2d3e2aa985f57e40a87a02"
+                        ] as [String : Any]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 7:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [
+                        "_socialIdentity" : [
+                            "kinveyAuth": [
+                                "access_token" : "a10a3743028e2e92b97037825b50a2666608b874",
+                                "refresh_token" : "627b034f5ec409899252a8017cb710566dfd2620",
+                                "id" : "custom",
+                                "audience" : MockKinveyBackend.kid
+                            ]
+                        ],
+                        "username" : "3b788b0c-cb99-4692-b3ae-a6b10b3d76f2",
+                        "password" : "fa0f771f-6480-4f11-a11b-dc85cce52beb",
+                        "_kmd" : [
+                            "lmt" : "2016-09-01T01:48:01.177Z",
+                            "ect" : "2016-09-01T01:48:01.177Z",
+                            "authtoken" : "12ed2b41-a5a1-4f37-a640-3a9c62c3fefd.rUHKOlQuRb4pW4NjmCimJ64rd2BF3drXy1SjHtuVCoM="
+                        ],
+                        "_id" : "57c788d168d976c525ee4602",
+                        "_acl" : [
+                            "creator" : "57c788d168d976c525ee4602"
+                        ]
+                    ] as [String : Any]
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                case 8:
+                    let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: ["Content-Type" : "application/json; charset=utf-8"])!
+                    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                    let json = [[String : Any]]()
+                    let data = try! JSONSerialization.data(withJSONObject: json)
+                    client?.urlProtocol(self, didLoad: data)
+                    client?.urlProtocolDidFinishLoading(self)
+                default:
+                    XCTFail()
+                }
+                type(of: self).count += 1
+            }
+            
+            override func stopLoading() {
+            }
+        }
+        
+        setURLProtocol(MICLoginAutomatedAuthorizationGrantFlowURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        XCTAssertNil(client.activeUser)
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        let redirectURI = URL(string: "micAuthGrantFlow://")!
+        User.login(
+            redirectURI: redirectURI,
+            username: "custom",
+            password: "1234",
+            authServiceId: MICLoginAutomatedAuthorizationGrantFlowURLProtocol.authServiceId
         ) { user, error in
             XCTAssertNotNil(user)
             XCTAssertNil(error)
@@ -4181,6 +4407,9 @@ extension UserTests {
     
     func testUserLockDownWithRefreshToken() {
         userLockDown(mustIncludeSocialIdentity: true)
+    }
+    
+    func testAuthServiceId() {
     }
     
 }


### PR DESCRIPTION
#### Description

`authServiceID` using a BasicAuth credential for MIC calls

#### Changes

- For `/oauth/token` and refresh token calls we are now considering the `authServiceID` parameter

#### Tests

- New unit test based in an existing one
