### PR TITLE
MLIBZ-2439: User and Entity classes now conforms to Hashable and Equatable

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -165,6 +165,35 @@ open class Entity: Object, Persistable {
     
 }
 
+extension Entity /* Hashable */ {
+    
+    open override var hashValue: Int {
+        return entityId?.hashValue ?? 0
+    }
+    
+    // Obj-C
+    open override var hash: Int {
+        return hashValue
+    }
+    
+}
+
+extension Entity /* Equatable */ {
+    
+    open static func == (lhs: Entity, rhs: Entity) -> Bool {
+        return lhs.entityId == rhs.entityId
+    }
+    
+    // Obj-C
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let otherEntity = object as? Entity else {
+            return false
+        }
+        return self == otherEntity
+    }
+    
+}
+
 let mappingOperationQueue: OperationQueue = {
     let operationQueue = OperationQueue()
     operationQueue.name = "Kinvey Property Mapping"

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -1586,6 +1586,35 @@ open class User: NSObject, Credential, Mappable {
 
 }
 
+extension User /* Hashable */ {
+
+    open override var hashValue: Int {
+        return userId.hashValue
+    }
+    
+    // Obj-C
+    open override var hash: Int {
+        return hashValue
+    }
+
+}
+
+extension User /* Equatable */ {
+
+    open static func == (lhs: User, rhs: User) -> Bool {
+        return lhs.userId == rhs.userId
+    }
+
+    // Obj-C
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let otherUser = object as? User else {
+            return false
+        }
+        return self == otherUser
+    }
+
+}
+
 /// Holds the Social Identities attached to a specific User
 public struct UserSocialIdentity : StaticMappable {
     

--- a/Kinvey/KinveyTests/EntityTestCase.swift
+++ b/Kinvey/KinveyTests/EntityTestCase.swift
@@ -103,4 +103,36 @@ class EntityTestCase: XCTestCase {
         XCTAssertNil(clazz)
     }
     
+    func testEntityHashable() {
+        let entityId = UUID().uuidString
+        let entity1 = Person { $0.entityId = entityId }
+        let entity2 = Person { $0.entityId = entityId }
+        let entity3 = Person { $0.entityId = UUID().uuidString }
+        XCTAssertEqual(entity1.hash, entity2.hash)
+        XCTAssertEqual(entity1.hashValue, entity2.hashValue)
+        XCTAssertNotEqual(entity1.hash, entity3.hash)
+        XCTAssertNotEqual(entity2.hash, entity3.hash)
+        XCTAssertNotEqual(entity1.hashValue, entity3.hashValue)
+        XCTAssertNotEqual(entity2.hashValue, entity3.hashValue)
+    }
+    
+    func testEntityEquatable() {
+        let entityId = UUID().uuidString
+        let entity1 = Person { $0.entityId = entityId }
+        let entity2 = Person { $0.entityId = entityId }
+        let entity3 = Person { $0.entityId = UUID().uuidString }
+        let set = Set<Person>([entity1])
+        XCTAssertEqual(entity1, entity2)
+        XCTAssertNotEqual(entity1, entity3)
+        XCTAssertNotEqual(entity2, entity3)
+        XCTAssertTrue(entity1 == entity2)
+        XCTAssertFalse(entity1 == entity3)
+        XCTAssertFalse(entity2 == entity3)
+        XCTAssertTrue(entity1.isEqual(entity2))
+        XCTAssertFalse(entity1.isEqual(entity3))
+        XCTAssertFalse(entity2.isEqual(entity3))
+        XCTAssertTrue(set.contains(entity2))
+        XCTAssertFalse(set.contains(entity3))
+    }
+    
 }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -4183,6 +4183,25 @@ extension UserTests {
         userLockDown(mustIncludeSocialIdentity: true)
     }
     
+    func testUserHashable() {
+        let userId = UUID().uuidString
+        let user1 = User(userId: userId)
+        let user2 = User(userId: userId)
+        XCTAssertEqual(user1.hash, user2.hash)
+        XCTAssertEqual(user1.hashValue, user2.hashValue)
+    }
+    
+    func testUserEquatable() {
+        let userId = UUID().uuidString
+        let user1 = User(userId: userId)
+        let user2 = User(userId: userId)
+        let set = Set<User>([user1])
+        XCTAssertEqual(user1, user2)
+        XCTAssertTrue(user1 == user2)
+        XCTAssertTrue(user1.isEqual(user2))
+        XCTAssertTrue(set.contains(user2))
+    }
+    
 }
 
 #endif

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -4187,19 +4187,32 @@ extension UserTests {
         let userId = UUID().uuidString
         let user1 = User(userId: userId)
         let user2 = User(userId: userId)
+        let user3 = User(userId: UUID().uuidString)
         XCTAssertEqual(user1.hash, user2.hash)
         XCTAssertEqual(user1.hashValue, user2.hashValue)
+        XCTAssertNotEqual(user1.hash, user3.hash)
+        XCTAssertNotEqual(user2.hash, user3.hash)
+        XCTAssertNotEqual(user1.hashValue, user3.hashValue)
+        XCTAssertNotEqual(user2.hashValue, user3.hashValue)
     }
     
     func testUserEquatable() {
         let userId = UUID().uuidString
         let user1 = User(userId: userId)
         let user2 = User(userId: userId)
+        let user3 = User(userId: UUID().uuidString)
         let set = Set<User>([user1])
         XCTAssertEqual(user1, user2)
+        XCTAssertNotEqual(user1, user3)
+        XCTAssertNotEqual(user2, user3)
         XCTAssertTrue(user1 == user2)
+        XCTAssertFalse(user1 == user3)
+        XCTAssertFalse(user2 == user3)
         XCTAssertTrue(user1.isEqual(user2))
+        XCTAssertFalse(user1.isEqual(user3))
+        XCTAssertFalse(user2.isEqual(user3))
         XCTAssertTrue(set.contains(user2))
+        XCTAssertFalse(set.contains(user3))
     }
     
 }


### PR DESCRIPTION
#### Description

`User` and `Entity` classes now conforms to Hashable and Equatable

#### Changes

- Adding methods for Hashable and Equatable in the `User` and `Entity` class

#### Tests

- Unit tests to double check Hashable and Equatable
