### PR TITLE
MLIBZ-2475: default log level must be warning

### DIFF
--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -99,7 +99,11 @@ extension XCGLogger.Level {
     }
 }
 
-let log = XCGLogger.default
+let log: XCGLogger = {
+    let log = XCGLogger.default
+    log.outputLevel = .warning
+    return log
+}()
 
 func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Never  {
     let message = message()

--- a/Kinvey/KinveyTests/LogTestCase.swift
+++ b/Kinvey/KinveyTests/LogTestCase.swift
@@ -23,8 +23,8 @@ class LogTestCase: XCTestCase {
     }
     
     func testLogLevelInitialState() {
-        XCTAssertEqual(Kinvey.log.outputLevel, XCGLogger.Level.debug)
-        XCTAssertEqual(Kinvey.LogLevel.debug, XCGLogger.Level.debug.logLevel)
+        XCTAssertEqual(Kinvey.log.outputLevel, XCGLogger.Level.warning)
+        XCTAssertEqual(Kinvey.LogLevel.warning, XCGLogger.Level.warning.logLevel)
     }
     
     func testLogLevelVerbose() {


### PR DESCRIPTION
#### Description

Default log level must be `.warning`

#### Changes

- `.warning` log level is set when the log is created

#### Tests

- Unit test changed to double check that
