### PR TITLE
MLIBZ-2485: skip and limit should not save the query last sync

### DIFF
--- a/Kinvey/Kinvey/PullOperation.swift
+++ b/Kinvey/Kinvey/PullOperation.swift
@@ -20,6 +20,7 @@ internal class PullOperation<T: Persistable>: FindOperation<T> where T: NSObject
         cache: AnyCache<T>?,
         options: Options?,
         mustSetRequestResult: Bool = true,
+        mustSaveQueryLastSync: Bool? = nil,
         resultsHandler: ResultsHandler? = nil
     ) {
         super.init(
@@ -31,6 +32,8 @@ internal class PullOperation<T: Persistable>: FindOperation<T> where T: NSObject
             validationStrategy: validationStrategy,
             cache: cache,
             options: options,
+            mustSetRequestResult: mustSetRequestResult,
+            mustSaveQueryLastSync: mustSaveQueryLastSync,
             resultsHandler: resultsHandler
         )
     }

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -2274,6 +2274,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 expectationPull = nil
             }
         }
+        
+        XCTAssertNotNil(store.cache?.lastSync(query: Query()))
     }
     
     func testDeltaSet3rdPull() {


### PR DESCRIPTION
#### Description

- Making sure to not save the query last sync date if skip and limit is being used

#### Changes

- `FindOperation` (which is also the base class for `PullOperation`) is now checking for `skip` and `limit` usage, but also considering other scenarios like `autoPagination` for example

#### Tests

- Unit test added to check the cache data
