### PR TITLE
MLIBZ-2490: pull with skip should not remove cached records

### DIFF
--- a/Kinvey/Kinvey/PullOperation.swift
+++ b/Kinvey/Kinvey/PullOperation.swift
@@ -39,7 +39,7 @@ internal class PullOperation<T: Persistable>: FindOperation<T> where T: NSObject
     }
     
     override var mustRemoveCachedRecords: Bool {
-        return true
+        return isSkipAndLimitNil
     }
     
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -7121,10 +7121,25 @@ class SyncStoreTests: StoreTestCase {
                 if let skipString = urlComponents.queryItems?.filter({ $0.name == "skip" }).first?.value,
                     let skip = Int(skipString)
                 {
-                    return HttpResponse(json: Array(json[skip...]))
+                    return HttpResponse(
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        json: Array(json[skip...])
+                    )
                 }
-                return HttpResponse(json: json)
+                return HttpResponse(
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    json: json
+                )
+            case "/appdata/_kid_/Person/_deltaset":
+                return HttpResponse(
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    json: [
+                        "changed" : [],
+                        "deleted" : []
+                    ]
+                )
             default:
+                XCTFail(urlComponents.path)
                 return HttpResponse(statusCode: 404, data: Data())
             }
         }
@@ -7132,7 +7147,7 @@ class SyncStoreTests: StoreTestCase {
             setURLProtocol(nil)
         }
         
-        let dataStore = DataStore<Person>.collection(.sync)
+        let dataStore = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         do {
             var results = try dataStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()


### PR DESCRIPTION
#### Description

When skip and limit is used we should not remove cached records

#### Changes

- `PullOperation` now checks if the `skip` and `limit` are `nil` to determine if local records should be deleted before save the records pulled from the server

#### Tests

- Unit Test added to reproduce the scenario described in the JIRA ticket
