### PR TITLE
MLIBZ-2481: bugfix for cancel find requests

### DIFF
--- a/Kinvey/Kinvey/FindOperation.swift
+++ b/Kinvey/Kinvey/FindOperation.swift
@@ -260,6 +260,7 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
                 }
             }
             multiRequest.progress.addChild(request.progress, withPendingUnitCount: 99)
+            multiRequest += request
         }.recover { (error) -> Promise<AnyRandomAccessCollection<T>> in
             if let cache = self.cache,
                 let error = error as? Kinvey.Error
@@ -324,6 +325,7 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
                 }
             }
             multiRequest.progress.addChild(request.progress, withPendingUnitCount: 99)
+            multiRequest += request
         }
     }
     


### PR DESCRIPTION
#### Description

Bugfix for cancel find requests

#### Changes

- `FindOperation` uses `MultiRequest` for cases like `autoPagination` for example. We were not adding the child requests to the `multiRequest` instance in 2 situations, which was causing the bug. 

#### Tests

- Unit Test added. TDD approach.
