### PR TITLE
MLIBZ-2510: removing compiler warnings

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -282,7 +282,6 @@
 		57A3EBBC1DDAC87B00983D2F /* auth.html in Resources */ = {isa = PBXBuildFile; fileRef = 57A3EBBA1DDA8BB900983D2F /* auth.html */; };
 		57A4656D1CBEF7B6009E7384 /* PersistableTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A4656C1CBEF7B6009E7384 /* PersistableTestCase.swift */; };
 		57A4656F1CC00931009E7384 /* PerformanceTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A4656E1CC00931009E7384 /* PerformanceTestCase.swift */; };
-		57A4658C1CC02ADB009E7384 /* PerformanceTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A4656E1CC00931009E7384 /* PerformanceTestCase.swift */; };
 		57A4658D1CC02AE3009E7384 /* StoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5706FEC21C1F9A6D0037E7D0 /* StoreTestCase.swift */; };
 		57A4658E1CC02AE6009E7384 /* KinveyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A27C901C178F18000DF951 /* KinveyTestCase.swift */; };
 		57A4658F1CC02AEF009E7384 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571991081CB45EEE00070CDA /* Person.swift */; };
@@ -2292,7 +2291,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Kinvey;
 				TargetAttributes = {
 					570423F51F82EC3E00EE5CBD = {
@@ -3266,7 +3265,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5706D9981DDFFC94009836D5 /* MockKinveyBackend.swift in Sources */,
-				57A4658C1CC02ADB009E7384 /* PerformanceTestCase.swift in Sources */,
 				57A4658D1CC02AE3009E7384 /* StoreTestCase.swift in Sources */,
 				57A4658F1CC02AEF009E7384 /* Person.swift in Sources */,
 				57A4658E1CC02AE6009E7384 /* KinveyTestCase.swift in Sources */,
@@ -4059,6 +4057,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.SSOApp1Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SSOApp1.app/SSOApp1";
 			};
 			name = Debug;
@@ -4082,6 +4081,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.SSOApp1Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SSOApp1.app/SSOApp1";
 			};
 			name = Release;
@@ -4153,6 +4153,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.SSOApp2Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SSOApp2.app/SSOApp2";
 			};
 			name = Debug;
@@ -4176,6 +4177,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.SSOApp2Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SSOApp2.app/SSOApp2";
 			};
 			name = Release;
@@ -4198,6 +4200,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4218,6 +4221,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4239,6 +4243,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4259,6 +4264,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4320,6 +4326,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4339,6 +4346,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4354,12 +4362,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -4409,12 +4419,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -4516,6 +4528,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4531,6 +4544,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4550,6 +4564,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KinveyApp.app/KinveyApp";
 			};
 			name = Debug;
@@ -4570,6 +4585,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KinveyApp.app/KinveyApp";
 			};
 			name = Release;
@@ -4591,6 +4607,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4610,6 +4627,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4630,6 +4648,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4649,6 +4668,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};
@@ -4669,6 +4689,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Debug;
 		};
@@ -4688,6 +4709,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SUPPRESS_WARNINGS = YES;
 			};
 			name = Release;
 		};

--- a/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey-macOS.xcscheme
+++ b/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -80,7 +79,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey.xcscheme
+++ b/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Kinvey/Kinvey/Geolocation.swift
+++ b/Kinvey/Kinvey/Geolocation.swift
@@ -108,6 +108,14 @@ public func <- (left: inout GeoPoint?, right: (String, Map)) {
     left <- (map, transform)
 }
 
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: inout GeoPoint!, right: (String, Map)) {
+    let (right, map) = right
+    let transform = GeoPointTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
+    left <- (map, transform)
+}
+
 func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
     return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
 }

--- a/Kinvey/Kinvey/Geolocation.swift
+++ b/Kinvey/Kinvey/Geolocation.swift
@@ -108,14 +108,6 @@ public func <- (left: inout GeoPoint?, right: (String, Map)) {
     left <- (map, transform)
 }
 
-/// Override operator used during the `propertyMapping(_:)` method.
-public func <- (left: inout GeoPoint!, right: (String, Map)) {
-    let (right, map) = right
-    let transform = GeoPointTransform()
-    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
-    left <- (map, transform)
-}
-
 func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
     return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
 }

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -118,6 +118,13 @@ public func <- <T>(left: inout T?, right: (String, Map)) {
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
+public func <- <T>(left: inout T!, right: (String, Map)) {
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T, right: (String, Map)) {
     let (right, map) = right
     kinveyMappingType(left: right, right: map.currentKey!)
@@ -126,6 +133,13 @@ public func <- <T: BaseMappable>(left: inout T, right: (String, Map)) {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T?, right: (String, Map)) {
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- <T: BaseMappable>(left: inout T!, right: (String, Map)) {
     let (right, map) = right
     kinveyMappingType(left: right, right: map.currentKey!)
     left <- map
@@ -145,6 +159,13 @@ public func <- <Transform: TransformType>(left: inout Transform.Object?, right: 
     left <- (map, transform)
 }
 
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (String, Map, Transform)) {
+    let (right, map, transform) = right
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
+    left <- (map, transform)
+}
+
 // MARK: Default Date Transform
 
 /// Override operator used during the `propertyMapping(_:)` method.
@@ -157,6 +178,14 @@ public func <- (left: inout Date, right: (String, Map)) {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: inout Date?, right: (String, Map)) {
+    let (right, map) = right
+    let transform = KinveyDateTransform()
+    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
+    left <- (map, transform)
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: inout Date!, right: (String, Map)) {
     let (right, map) = right
     let transform = KinveyDateTransform()
     kinveyMappingType(left: right, right: map.currentKey!, transform: transform)

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -118,13 +118,6 @@ public func <- <T>(left: inout T?, right: (String, Map)) {
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
-public func <- <T>(left: inout T!, right: (String, Map)) {
-    let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
-    left <- map
-}
-
-/// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T, right: (String, Map)) {
     let (right, map) = right
     kinveyMappingType(left: right, right: map.currentKey!)
@@ -133,13 +126,6 @@ public func <- <T: BaseMappable>(left: inout T, right: (String, Map)) {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T?, right: (String, Map)) {
-    let (right, map) = right
-    kinveyMappingType(left: right, right: map.currentKey!)
-    left <- map
-}
-
-/// Override operator used during the `propertyMapping(_:)` method.
-public func <- <T: BaseMappable>(left: inout T!, right: (String, Map)) {
     let (right, map) = right
     kinveyMappingType(left: right, right: map.currentKey!)
     left <- map
@@ -159,13 +145,6 @@ public func <- <Transform: TransformType>(left: inout Transform.Object?, right: 
     left <- (map, transform)
 }
 
-/// Override operator used during the `propertyMapping(_:)` method.
-public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (String, Map, Transform)) {
-    let (right, map, transform) = right
-    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
-    left <- (map, transform)
-}
-
 // MARK: Default Date Transform
 
 /// Override operator used during the `propertyMapping(_:)` method.
@@ -178,14 +157,6 @@ public func <- (left: inout Date, right: (String, Map)) {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: inout Date?, right: (String, Map)) {
-    let (right, map) = right
-    let transform = KinveyDateTransform()
-    kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
-    left <- (map, transform)
-}
-
-/// Override operator used during the `propertyMapping(_:)` method.
-public func <- (left: inout Date!, right: (String, Map)) {
     let (right, map) = right
     let transform = KinveyDateTransform()
     kinveyMappingType(left: right, right: map.currentKey!, transform: transform)
@@ -572,11 +543,7 @@ extension Persistable where Self: NSObject {
 extension AnyRandomAccessCollection where Element: Persistable {
     
     public subscript(idx: Int) -> Element {
-        return self[Int64(idx)]
-    }
-    
-    public subscript(idx: Int64) -> Element {
-        return self[index(startIndex, offsetBy: idx)]
+        return self[AnyIndex(idx)]
     }
     
 }

--- a/Kinvey/KinveyApp/PerformanceTestData.swift
+++ b/Kinvey/KinveyApp/PerformanceTestData.swift
@@ -14,7 +14,7 @@ class PerformanceTestData: UIViewController {
     let client = Client(appKey: "kid_b1d6IY_x7l", appSecret: "079412ee99f4485d85e6e362fb987de8")
     
     func store<T: Persistable>() -> DataStore<T> where T: NSObject {
-        return DataStore<T>.collection(.network, client: self.client)
+        return DataStore<T>.collection(.network, options: Options(client: self.client))
     }
     
     @IBOutlet dynamic weak var startDateLabel: UILabel!

--- a/Kinvey/KinveyApp/PerformanceTestMedData.swift
+++ b/Kinvey/KinveyApp/PerformanceTestMedData.swift
@@ -14,9 +14,14 @@ class PerformanceTestMedData: PerformanceTestData {
     override func test() {
         startDate = Date()
         let store: DataStore<MedData> = self.store()
-        store.find(deltaSet: deltaSetSwitch.isOn) { results, error in
+        store.find(options: Options(deltaSet: deltaSetSwitch.isOn)) { (result: Result<AnyRandomAccessCollection<MedData>, Swift.Error>) in
             self.endDate = Date()
-            self.durationLabel.text = "\(self.durationLabel.text ?? "")\n\(results?.count ?? 0)"
+            switch result {
+            case .success(let results):
+                self.durationLabel.text = "\(self.durationLabel.text ?? "")\n\(results.count)"
+            case .failure(let error):
+                self.durationLabel.text = "\(self.durationLabel.text ?? "")\nError: \(error.localizedDescription)"
+            }
         }
     }
     

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -418,7 +418,7 @@ class DataType: Entity {
     dynamic var fullName2DefaultValueTransformed = FullName2()
     
     @objc
-    dynamic var fullName2DefaultValueNotOptionalTransformed: FullName2! = FullName2()
+    dynamic var fullName2DefaultValueNotOptionalTransformed = FullName2()
     
     @objc
     fileprivate dynamic var colorValueString: String?

--- a/Kinvey/KinveyTests/EntityTestCase.swift
+++ b/Kinvey/KinveyTests/EntityTestCase.swift
@@ -67,13 +67,22 @@ class EntityTestCase: XCTestCase {
         XCTAssertEqual(geoPoint.longitude, longitude)
     }
     
-    func testGeoPointMapping2() {
+    func testGeoPointMappingForce() {
         var geoPoint: GeoPoint!
         let latitude = 42.3133521
         let longitude = -71.1271963
         geoPoint <- ("geoPoint", Map(mappingType: .fromJSON, JSON: ["location" : [longitude, latitude]])["location"])
         XCTAssertEqual(geoPoint.latitude, latitude)
         XCTAssertEqual(geoPoint.longitude, longitude)
+    }
+    
+    func testGeoPointMappingOptional() {
+        var geoPoint: GeoPoint?
+        let latitude = 42.3133521
+        let longitude = -71.1271963
+        geoPoint <- ("geoPoint", Map(mappingType: .fromJSON, JSON: ["location" : [longitude, latitude]])["location"])
+        XCTAssertEqual(geoPoint?.latitude, latitude)
+        XCTAssertEqual(geoPoint?.longitude, longitude)
     }
     
     func testPropertyType() {

--- a/Kinvey/SSOApp/SSOApp1/AppDelegate.swift
+++ b/Kinvey/SSOApp/SSOApp1/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-        if User.login(redirectURI: micRedirectURI, micURL: url, authServiceId: authServiceId) {
+        if User.login(redirectURI: micRedirectURI, micURL: url, options: Options(authServiceId: authServiceId)) {
             return true
         }
         


### PR DESCRIPTION
Removing compiler warnings and ignoring deprecation warnings for unit tests

#### Description

- After Swift 4.1 changes the compiler was throwing some warnings

#### Changes

- Mainly `Persistable.swift` and Unit Tests

#### Tests

- No need for additional unit tests
