### PR TITLE
MLIBZ-2511: writing auto pagination requests inside a transaction

### DIFF
--- a/Kinvey/KinveyTests/MemoryCache.swift
+++ b/Kinvey/KinveyTests/MemoryCache.swift
@@ -131,4 +131,24 @@ class MemoryCache<T: Persistable>: Cache<T>, CacheType where T: NSObject {
         Kinvey.fatalError("Method not implemented")
     }
     
+    func write(_ block: @escaping (() throws -> Void)) throws {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
+    func beginWrite() {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
+    func commitWrite() throws {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
+    func commitWrite(withoutNotifying tokens: [NotificationToken]) throws {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
+    func cancelWrite() {
+        Kinvey.fatalError("Method not implemented")
+    }
+    
 }


### PR DESCRIPTION
#### Description

When a 2nd or following requests fails in a auto pagination request, the last sync date should not be saved

#### Changes

- `FindOperation` should start a transaction before start performing the auto pagination requests

#### Tests

- Unit tests added (TDD)
