### PR TITLE
MLIBZ-2527: handling OAuth MIC errors in redirect uri

### DIFF
--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -95,6 +95,9 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     
     case invalidCredentials(httpResponse: HTTPURLResponse?, data: Data?, debug: String, description: String)
     
+    /// Error handling OAuth errors in redirect uri responses
+    case micAuth(error: String, description: String)
+    
     /// Error localized description.
     public var description: String {
         let bundle = Bundle(for: Client.self)
@@ -111,7 +114,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .resultSetSizeExceeded(_, let description),
              .entityNotFound(_, let description),
              .parameterValueOutOfRange(_, let description),
-             .invalidCredentials(_, _, _, let description):
+             .invalidCredentials(_, _, _, let description),
+             .micAuth(_, let description):
             return description
         case .objectIdMissing:
             return NSLocalizedString("Error.objectIdMissing", bundle: bundle, comment: "")

--- a/Kinvey/Kinvey/MIC.swift
+++ b/Kinvey/Kinvey/MIC.swift
@@ -590,7 +590,10 @@ class MICLoginViewController: UIViewController, WKNavigationDelegate, UIWebViewD
                 success(code: code)
                 return false
             case .failure(let error):
-                failure(error: error ?? buildError(nil, nil, error, options?.client ?? sharedClient))
+                if let error = error {
+                    failure(error: error)
+                    return false
+                }
             }
         }
         return true

--- a/Kinvey/Kinvey/MIC.swift
+++ b/Kinvey/Kinvey/MIC.swift
@@ -44,10 +44,29 @@ open class MIC {
             return .failure(nil)
         }
         
-        if let code = queryItems.filter({ $0.name == "code" && $0.value != nil && !$0.value!.isEmpty }).first?.value {
+        var code: String? = nil
+        var error: String? = nil
+        var errorDescription: String? = nil
+        for queryItem in queryItems {
+            guard let value = queryItem.value, !value.isEmpty else {
+                continue
+            }
+            switch queryItem.name {
+            case "code":
+                code = value
+            case "error":
+                error = value
+            case "error_description":
+                errorDescription = value
+            default:
+                break
+            }
+        }
+        
+        if let code = code {
             return .success(code)
-        } else if let error = queryItems.filter({ $0.name == "error" && $0.value != nil && !$0.value!.isEmpty }).first?.value,
-            let errorDescription = queryItems.filter({ $0.name == "error_description" && $0.value != nil && !$0.value!.isEmpty }).first?.value
+        } else if let error = error,
+            let errorDescription = errorDescription
         {
             return .failure(Error.micAuth(error: error, description: errorDescription))
         }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -3345,6 +3345,74 @@ class UserTests: KinveyTestCase {
         }
     }
     
+    func testMICLoginUsernamePasswordRedirectError() {
+        var count = 0
+        let errorCode = "server_error"
+        let errorDescription = "server_error_description"
+        mockResponse { (request) -> HttpResponse in
+            defer {
+                count += 1
+            }
+            switch count {
+            case 0:
+                return HttpResponse(
+                    statusCode: 200,
+                    json: [
+                        "temp_login_uri" : "https://auth.kinvey.com/oauth/authenticate/\(UUID().uuidString)"
+                    ]
+                )
+            case 1:
+                return HttpResponse(
+                    statusCode: 302,
+                    headerFields: ["Location" : "myCustomURIScheme://?error=\(errorCode)&error_description=\(errorDescription)"],
+                    data: Data()
+                )
+            default:
+                XCTFail()
+                return HttpResponse(statusCode: 200, data: Data())
+            }
+        }
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(
+            redirectURI: URL(string: "myCustomURIScheme://")!,
+            username: UUID().uuidString,
+            password: UUID().uuidString,
+            options: Options(
+                authServiceId: nil
+            )
+        ) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                XCTAssertNotNil(error as? Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .micAuth(let code, let description):
+                        XCTAssertEqual(errorCode, code)
+                        XCTAssertEqual(errorDescription, description)
+                    default:
+                        XCTFail(error.description)
+                    }
+                }
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+    }
+    
     func testUserWithoutUserID() {
         XCTAssertNil(User(JSON: ["username" : "Test"]))
     }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -3075,8 +3075,12 @@ class UserTests: KinveyTestCase {
     func testMICParseCode() {
         let redirectURI = URL(string: "myCustomURIScheme://")!
         let url = URL(string: "myCustomURIScheme://?code_not_present=1234")!
-        let code = MIC.parseCode(redirectURI: redirectURI, url: url)
-        XCTAssertNil(code)
+        switch MIC.parseCode(redirectURI: redirectURI, url: url) {
+        case .success(let code):
+            XCTFail(code)
+        case .failure(let error):
+            XCTAssertNil(error)
+        }
     }
     
     func testMICLoginTimeout() {


### PR DESCRIPTION
#### Description

MIC v3 and above can now return `error` and `error_description` in the redirect uri

#### Changes

- `MIC.parseCode` now can handle when errors are returned

#### Tests

- Unit tests to cover this case (TDD)
