### PR TITLE
MLIBZ-2536: remove deprecated methods

### DIFF
--- a/Kinvey.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Kinvey.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Kinvey/Kinvey/Acl.swift
+++ b/Kinvey/Kinvey/Acl.swift
@@ -126,7 +126,7 @@ extension Acl: Mappable {
     
     /// Constructor that validates if the map contains at least the creator.
     public convenience init?(map: Map) {
-        guard let _: String = map[Acl.Key.creator].value() else {
+        guard let _: String = map[Acl.CodingKeys.creator].value() else {
             self.init()
             return nil
         }
@@ -136,11 +136,11 @@ extension Acl: Mappable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        creator <- ("creator", map[Acl.Key.creator])
-        globalRead.value <- ("globalRead", map[Acl.Key.globalRead])
-        globalWrite.value <- ("globalWrite", map[Acl.Key.globalWrite])
-        readers <- ("readers", map[Acl.Key.readers])
-        writers <- ("writers", map[Acl.Key.writers])
+        creator <- ("creator", map[Acl.CodingKeys.creator])
+        globalRead.value <- ("globalRead", map[Acl.CodingKeys.globalRead])
+        globalWrite.value <- ("globalWrite", map[Acl.CodingKeys.globalWrite])
+        readers <- ("readers", map[Acl.CodingKeys.readers])
+        writers <- ("writers", map[Acl.CodingKeys.writers])
     }
     
 }
@@ -148,6 +148,7 @@ extension Acl: Mappable {
 extension Acl {
     
     /// Property names for Acl
+    @available(*, deprecated: 3.17.0, message: "Please use Acl.CodingKeys instead")
     public struct Key {
         
         static let creator = "creator"
@@ -155,6 +156,21 @@ extension Acl {
         static let globalWrite = "gw"
         static let readers = "r"
         static let writers = "w"
+        
+    }
+    
+}
+
+extension Acl {
+    
+    /// Property names for Acl
+    public enum CodingKeys: String, CodingKey {
+        
+        case creator = "creator"
+        case globalRead = "gr"
+        case globalWrite = "gw"
+        case readers = "r"
+        case writers = "w"
         
     }
     

--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -191,7 +191,7 @@ open class Client: Credential {
     
     /// Initialize a `Client` instance with all the needed parameters and requires a boolean to encrypt or not any store created using this client instance.
     @available(*, deprecated: 3.17.0, message: "Please use Client.initialize(appKey:appSecret:accessGroup:apiHostName:authHostName:encrypted:schema:completionHandler:(Result<User?, Swift.Error>) -> Void")
-    open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: User.UserHandler<U>) {
+    open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: @escaping User.UserHandler<U>) {
         initialize(
             appKey: appKey,
             appSecret: appSecret,
@@ -211,7 +211,17 @@ open class Client: Credential {
     }
     
     /// Initialize a `Client` instance with all the needed parameters and requires a boolean to encrypt or not any store created using this client instance.
-    open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: (Result<U?, Swift.Error>) -> Void) {
+    open func initialize<U: User>(
+        appKey: String,
+        appSecret: String,
+        accessGroup: String? = nil,
+        apiHostName: URL = Client.defaultApiHostName,
+        authHostName: URL = Client.defaultAuthHostName,
+        encrypted: Bool,
+        schema: Schema? = nil,
+        options: Options? = nil,
+        completionHandler: @escaping (Result<U?, Swift.Error>) -> Void)
+    {
         validateInitialize(appKey: appKey, appSecret: appSecret)
 
         var encryptionKey: Data? = nil
@@ -235,11 +245,21 @@ open class Client: Credential {
             lockEncryptionKey.unlock()
         }
         
-        initialize(appKey: appKey, appSecret: appSecret, apiHostName: apiHostName, authHostName: authHostName, encryptionKey: encryptionKey, schema: Schema(version: schema?.version ?? 0, migrationHandler: schema?.migrationHandler)) { activeUser, error in
-        }
+        initialize(
+            appKey: appKey,
+            appSecret: appSecret,
+            accessGroup: accessGroup,
+            apiHostName: apiHostName,
+            authHostName: authHostName,
+            encryptionKey: encryptionKey,
+            schema: Schema(version: schema?.version ?? 0, migrationHandler: schema?.migrationHandler),
+            options: options,
+            completionHandler: completionHandler
+        )
     }
     
     /// Initialize a `Client` instance with all the needed parameters.
+    @available(*, deprecated: 3.17.0, message: "Please use Client.initialize(appKey:appSecret:accessGroup:apiHostName:authHostName:encryptionKey:schema:completionHandler:(Result<U?, Swift.Error>) -> Void) instead")
     open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encryptionKey: Data? = nil, schema: Schema? = nil, completionHandler: @escaping User.UserHandler<U>) {
         initialize(
             appKey: appKey,
@@ -354,7 +374,7 @@ open class Client: Credential {
             let customUser = user as! U
             completionHandler(.success(customUser))
         } else if let kinveyAuth = sharedKeychain?.kinveyAuth {
-            User.login(authSource: .kinvey, kinveyAuth, client: self) { (result: Result<U, Swift.Error>) in
+            User.login(authSource: .kinvey, kinveyAuth, options: Options(client: self)) { (result: Result<U, Swift.Error>) in
                 switch result {
                 case .success(let user):
                     completionHandler(.success(user))

--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -88,20 +88,6 @@ open class Client: Credential {
     /// Cache policy for this client instance.
     open var cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy
     
-    /// Timeout interval for this client instance.
-    @available(*, deprecated: 3.12.2, message: "Please use `options` instead")
-    open var timeoutInterval: TimeInterval {
-        get {
-            return options?.timeout ?? Client.urlSessionConfiguration.timeoutIntervalForRequest
-        }
-        set {
-            if options == nil {
-                options = Options()
-            }
-            options?.timeout = newValue
-        }
-    }
-    
     /**
      Hold default optional values for all calls made by this `Client` instance
      */
@@ -204,13 +190,7 @@ open class Client: Credential {
     }
     
     /// Initialize a `Client` instance with all the needed parameters and requires a boolean to encrypt or not any store created using this client instance.
-    @available(*, deprecated: 3.3.3, message: "Please use initialize(appKey:appSecret:accessGroup:apiHostName:authHostName:encrypted:schema:completionHandler:)")
-    open func initialize(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schemaVersion: CUnsignedLongLong = 0, migrationHandler: Migration.MigrationHandler? = nil) {
-        initialize(appKey: appKey, appSecret: appSecret, accessGroup: accessGroup, apiHostName: apiHostName, authHostName: authHostName, encrypted: encrypted, schema: Schema(schemaVersion, migrationHandler: migrationHandler)) { activeUser, error in
-        }
-    }
-    
-    /// Initialize a `Client` instance with all the needed parameters and requires a boolean to encrypt or not any store created using this client instance.
+    @available(*, deprecated: 3.17.0, message: "Please use Client.initialize(appKey:appSecret:accessGroup:apiHostName:authHostName:encrypted:schema:completionHandler:(Result<User?, Swift.Error>) -> Void")
     open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: User.UserHandler<U>) {
         initialize(
             appKey: appKey,
@@ -220,7 +200,7 @@ open class Client: Credential {
             authHostName: authHostName,
             encrypted: encrypted,
             schema: schema
-        ) { (result: Result<U, Swift.Error>) in
+        ) { (result: Result<U?, Swift.Error>) in
             switch result {
             case .success(let user):
                 completionHandler(user, nil)
@@ -231,7 +211,7 @@ open class Client: Credential {
     }
     
     /// Initialize a `Client` instance with all the needed parameters and requires a boolean to encrypt or not any store created using this client instance.
-    open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: (Result<U, Swift.Error>) -> Void) {
+    open func initialize<U: User>(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encrypted: Bool, schema: Schema? = nil, completionHandler: (Result<U?, Swift.Error>) -> Void) {
         validateInitialize(appKey: appKey, appSecret: appSecret)
 
         var encryptionKey: Data? = nil
@@ -256,13 +236,6 @@ open class Client: Credential {
         }
         
         initialize(appKey: appKey, appSecret: appSecret, apiHostName: apiHostName, authHostName: authHostName, encryptionKey: encryptionKey, schema: Schema(version: schema?.version ?? 0, migrationHandler: schema?.migrationHandler)) { activeUser, error in
-        }
-    }
-    
-    /// Initialize a `Client` instance with all the needed parameters.
-    @available(*, deprecated: 3.3.3, message: "Please use initialize(appKey:appSecret:accessGroup:apiHostName:authHostName:encryptionKey:schema:completionHandler:)")
-    open func initialize(appKey: String, appSecret: String, accessGroup: String? = nil, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encryptionKey: Data? = nil, schemaVersion: CUnsignedLongLong = 0, migrationHandler: Migration.MigrationHandler? = nil) {
-        initialize(appKey: appKey, appSecret: appSecret, accessGroup: accessGroup, apiHostName: apiHostName, authHostName: authHostName, encryptionKey: encryptionKey, schema: Schema(version: schemaVersion, migrationHandler: migrationHandler)) { activeUser, error in
         }
     }
     

--- a/Kinvey/Kinvey/CustomEndpoint.swift
+++ b/Kinvey/Kinvey/CustomEndpoint.swift
@@ -82,74 +82,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
-    @available(*, deprecated, message: "Please use the generic version of execute(params: CustomEndpoint.Params?) method")
-    open static func execute(
-        _ name: String,
-        params: JsonDictionary? = nil,
-        client: Client = sharedClient,
-        completionHandler: CompletionHandler<JsonDictionary>? = nil
-    ) -> AnyRequest<Result<JsonDictionary, Swift.Error>> {
-        let params = params != nil ? Params(params!) : nil
-        var request: AnyRequest<Result<JsonDictionary, Swift.Error>>!
-        Promise<JsonDictionary> { resolver in
-            request = callEndpoint(
-                name,
-                params: params,
-                options: Options(
-                    client: client
-                ),
-                resultType: Result<JsonDictionary, Swift.Error>.self
-            ) { data, response, error in
-                if let response = response, response.isOK, let json: JsonDictionary = client.responseParser.parse(data) {
-                    resolver.fulfill(json)
-                } else {
-                    resolver.reject(buildError(data, response, error, client))
-                }
-            }
-        }.done { json in
-            completionHandler?(json, nil)
-        }.catch { error in
-            completionHandler?(nil, error)
-        }
-        return request
-    }
-    
-    /// Executes a custom endpoint by name and passing the expected parameters.
-    @discardableResult
-    @available(*, deprecated, message: "Please use the generic version of execute(params: CustomEndpoint.Params?) method")
-    open static func execute(
-        _ name: String,
-        params: JsonDictionary? = nil,
-        client: Client = sharedClient,
-        completionHandler: CompletionHandler<[JsonDictionary]>? = nil
-    ) -> AnyRequest<Result<[JsonDictionary], Swift.Error>> {
-        let params = params != nil ? Params(params!) : nil
-        var request: AnyRequest<Result<[JsonDictionary], Swift.Error>>!
-        Promise<[JsonDictionary]> { resolver in
-            request = callEndpoint(
-                name,
-                params: params,
-                options: Options(
-                    client: client
-                ),
-                resultType: Result<[JsonDictionary], Swift.Error>.self
-            ) { data, response, error in
-                if let response = response, response.isOK, let json = client.responseParser.parseArray(data) {
-                    resolver.fulfill(json)
-                } else {
-                    resolver.reject(buildError(data, response, error, client))
-                }
-            }
-        }.done { jsonArray in
-            completionHandler?(jsonArray, nil)
-        }.catch { error in
-            completionHandler?(nil, error)
-        }
-        return request
-    }
-    
-    /// Executes a custom endpoint by name and passing the expected parameters.
-    @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute(
         _ name: String,
         params: Params? = nil,
@@ -172,6 +105,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute(
         _ name: String,
         params: Params? = nil,
@@ -224,6 +158,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute(
         _ name: String,
         params: Params? = nil,
@@ -246,6 +181,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute(
         _ name: String,
         params: Params? = nil,
@@ -300,6 +236,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute<T: BaseMappable>(
         _ name: String,
         params: Params? = nil,
@@ -322,6 +259,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute<T: BaseMappable>(
         _ name: String,
         params: Params? = nil,
@@ -374,6 +312,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute<T: BaseMappable>(
         _ name: String,
         params: Params? = nil,
@@ -396,6 +335,7 @@ open class CustomEndpoint {
     
     /// Executes a custom endpoint by name and passing the expected parameters.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use CustomEndpoint.execute(_:params:options:completionHandler:)")
     open static func execute<T: BaseMappable>(
         _ name: String,
         params: Params? = nil,

--- a/Kinvey/Kinvey/CustomEndpoint.swift
+++ b/Kinvey/Kinvey/CustomEndpoint.swift
@@ -52,6 +52,7 @@ open class CustomEndpoint {
     }
     
     /// Completion handler block for execute custom endpoints.
+    @available(*, deprecated: 3.17.0, message: "Please use Result<T, Swift.Error> instead")
     public typealias CompletionHandler<T> = (T?, Swift.Error?) -> Void
     
     private static func callEndpoint<Result>(

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -65,60 +65,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /**
-     Deprecated method. Please use `collection()` instead.
-     - Parameters:
-       - type: (Optional) Type for the new DataStore instance. Default value:
-     `.cache`
-       - deltaSet: (Optional) Enables delta set cache. Default value: `nil`
-       - client: (Optional) `Client` instance to be used for all requests.
-     Default value: `sharedClient`
-       - tag: (Optional) Tag the store and separate stores in different tags.
-     Default value: `defaultTag`
-       - validationStrategy: (Optional) Defines a strategy to validate results upfront. Default value: `nil`
-     - Returns: An instance of `DataStore` which can be a new instance or a cached instance if you are passing a `tag` parameter.
-     */
-    @available(*, deprecated: 3.0.22, message: "Please use `collection()` instead")
-    open class func getInstance(
-        _ type: StoreType = .cache,
-        deltaSet: Bool? = nil,
-        client: Client = sharedClient,
-        tag: String = defaultTag,
-        validationStrategy: ValidationStrategy? = nil
-    ) -> DataStore {
-        return collection(type, deltaSet: deltaSet, client: client, tag: tag)
-    }
-
-    /**
-     Factory method that returns a `DataStore`.
-     - parameter type: defines the data store type which will define the behavior of the `DataStore`. Default value: `Cache`
-     - parameter deltaSet: Enables delta set cache which will increase performance and reduce data consumption. Default value: `false`
-     - parameter client: define the `Client` to be used for all the requests for the `DataStore` that will be returned. Default value: `Kinvey.sharedClient`
-     - parameter tag: A tag/nickname for your `DataStore` which will cache instances with the same tag name. Default value: `Kinvey.defaultTag`
-     - parameter validationStrategy: (Optional) Defines a strategy to validate results upfront. Default value: `nil`
-     - returns: An instance of `DataStore` which can be a new instance or a cached instance if you are passing a `tag` parameter.
-     */
-    @available(*, deprecated: 3.13.0, message: "Please use `collection(options:)` instead")
-    open class func collection(
-        _ type: StoreType = .cache,
-        deltaSet: Bool? = nil,
-        autoPagination: Bool = false,
-        client: Client = sharedClient,
-        tag: String = defaultTag,
-        validationStrategy: ValidationStrategy? = nil
-    ) -> DataStore {
-        return collection(
-            type,
-            autoPagination: autoPagination,
-            tag: tag,
-            validationStrategy: validationStrategy,
-            options: Options {
-                $0.client = client
-                $0.deltaSet = deltaSet
-            }
-        )
-    }
-    
-    /**
      Factory method that returns a `DataStore`.
      - parameter type: defines the data store type which will define the behavior of the `DataStore`. Default value: `Cache`
      - parameter deltaSet: Enables delta set cache which will increase performance and reduce data consumption. Default value: `false`
@@ -199,43 +145,6 @@ open class DataStore<T: Persistable> where T: NSObject {
         self.validationStrategy = validationStrategy
     }
     
-    /**
-     Gets a single record using the `_id` of the record.
-     - parameter id: The `_id` value of the entity to be find
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(byId id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ObjectCompletionHandler) -> AnyRequest<Result<T, Swift.Error>> {
-        return find(byId: id, readPolicy: readPolicy) { (result: Result<T, Swift.Error>) in
-            switch result {
-            case .success(let obj):
-                completionHandler(obj, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Gets a single record using the `_id` of the record.
-     - parameter id: The `_id` value of the entity to be find
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(byId id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<T, Swift.Error>) -> Void) -> AnyRequest<Result<T, Swift.Error>> {
-        return find(id, readPolicy: readPolicy, completionHandler: completionHandler)
-    }
-    
     private func validate(id: String) {
         if id.isEmpty {
             fatalError("id cannot be an empty string")
@@ -245,69 +154,9 @@ open class DataStore<T: Persistable> where T: NSObject {
     /**
      Gets a single record using the `_id` of the record.
      
-     PS: This method is just a shortcut for `findById()`
      - parameter id: The `_id` value of the entity to be find
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(
-        _ id: String,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ObjectCompletionHandler
-    ) -> AnyRequest<Result<T, Swift.Error>> {
-        return find(
-            id,
-            readPolicy: readPolicy
-        ) { (result: Result<T, Swift.Error>) in
-            switch result {
-            case .success(let obj):
-                completionHandler(obj, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Gets a single record using the `_id` of the record.
-     
-     PS: This method is just a shortcut for `findById()`
-     - parameter id: The `_id` value of the entity to be find
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(
-        _ id: String,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<T, Swift.Error>) -> Void
-    ) -> AnyRequest<Result<T, Swift.Error>> {
-        return find(
-            id,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /**
-     Gets a single record using the `_id` of the record.
-     
-     PS: This method is just a shortcut for `findById()`
-     - parameter id: The `_id` value of the entity to be find
-     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
      - parameter completionHandler: Completion handler to be called once the respose returns
-     - returns: A `Request` instance which will allow cancel the request later
+     - returns: A `AnyRequest` instance which will allow cancel the request later
      */
     @discardableResult
     open func find(
@@ -333,100 +182,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
         }
         return request
-    }
-    
-    /**
-     Gets a list of records that matches with the query passed by parameter.
-     - parameter query: The query used to filter the results
-     - parameter deltaSet: Enforces delta set cache otherwise use the client's `deltaSet` value. Default value: `false`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(
-        _ query: Query = Query(),
-        deltaSet: Bool? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ArrayCompletionHandler
-    ) -> AnyRequest<Result<[T], Swift.Error>> {
-        return find(
-            query,
-            deltaSet: deltaSet,
-            readPolicy: readPolicy
-        ) { (result: Result<[T], Swift.Error>) in
-            switch result {
-            case .success(let objs):
-                completionHandler(objs, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Gets a list of records that matches with the query passed by parameter.
-     - parameter query: The query used to filter the results
-     - parameter deltaSet: Enforces delta set cache otherwise use the client's `deltaSet` value. Default value: `false`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use the `ReadPolicy` inferred from the store's type. Default value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use find(_:options:completionHandler:)")
-    @discardableResult
-    open func find(
-        _ query: Query = Query(),
-        deltaSet: Bool? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[T], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[T], Swift.Error>> {
-        return find(
-            query,
-            options: Options(
-                deltaSet: deltaSet,
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /**
-     Gets a list of records that matches with the query passed by parameter.
-     - parameter query: The query used to filter the results
-     - parameter deltaSet: Enforces delta set cache otherwise use the client's `deltaSet` value. Default value: `false`
-     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
-     - parameter completionHandler: Completion handler to be called once the respose returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.7.0, message: "Please use AnyRandomAccessCollection<T> instead of Array<T> (or [T]) for completion handlers")
-    @discardableResult
-    open func find(
-        _ query: Query = Query(),
-        options: Options? = nil,
-        completionHandler: @escaping (Result<[T], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[T], Swift.Error>> {
-        let convert = { (result: Result<AnyRandomAccessCollection<T>, Swift.Error>) -> Result<[T], Swift.Error> in
-            switch result {
-            case .success(let results):
-                return .success(Array(results))
-            case .failure(let error):
-                return .failure(error)
-            }
-        }
-        let request = find(query, options: options) { (result: Result<AnyRandomAccessCollection<T>, Swift.Error>) in
-            completionHandler(convert(result))
-        }
-        return AnyRequest(request) {
-            switch $0 {
-            case .some(let result):
-                return convert(result)
-            case .none:
-                return nil
-            }
-        }
     }
     
     /**
@@ -461,62 +216,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /**
-     Count of records that matches with the (optional) query parameter.
-     - parameter query: (Optional) The query used to filter the results. When
-     query is nil, gets the total count of the collection. Default value: `nil`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use the `ReadPolicy` inferred from the store's type. Default value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use count(_:options:completionHandler:)")
-    @discardableResult
-    open func count(
-        _ query: Query? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return count(
-            query,
-            readPolicy: readPolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Count of records that matches with the (optional) query parameter.
-     - parameter query: (Optional) The query used to filter the results. When
-     query is nil, gets the total count of the collection. Default value: `nil`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the `ReadPolicy` inferred from the store's type. Default
-     value: `ReadPolicy` inferred from the store's type
-     - parameter completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use count(_:options:completionHandler:)")
-    @discardableResult
-    open func count(
-        _ query: Query? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return count(
-            query,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /**
      Gets a count of how many records that matches with the (optional) query passed by parameter.
      - parameter query: The query used to filter the results
      - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
@@ -543,90 +242,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
         }
         return AnyRequest(request)
-    }
-    
-    /**
-     Custom aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - parameter keys: (Optional) Property names that should be grouped. Default
-     value: `nil`
-     - parameter initialObject: Sets an initial object that contains initial
-     values needed for the reduce function
-     - parameter reduceJSFunction: JavaScript reduce function that performs the
-     aggregation
-     - parameter condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the client's `ReadPolicy`. Default value: `nil`
-     - parameter completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:initialObject:reduceJSFunction:condition:options:completionHandler:)")
-    @discardableResult
-    open func group(
-        keys: [String]? = nil,
-        initialObject: JsonDictionary,
-        reduceJSFunction: String,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationCustomResult<T>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationCustomResult<T>], Swift.Error>> {
-        return group(
-            keys: keys,
-            initialObject: initialObject,
-            reduceJSFunction: reduceJSFunction,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationCustomResult<T>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Custom aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - parameter keys: (Optional) Property names that should be grouped. Default
-     value: `nil`
-     - parameter initialObject: Sets an initial object that contains initial
-     values needed for the reduce function
-     - parameter reduceJSFunction: JavaScript reduce function that performs the
-     aggregation
-     - parameter condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-     - parameter readPolicy: (Optional) Enforces a different `ReadPolicy`
-     otherwise use the client's `ReadPolicy`. Default value: `nil`
-     - parameter completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:initialObject:reduceJSFunction:condition:options:completionHandler:)")
-    @discardableResult
-    open func group(
-        keys: [String]? = nil,
-        initialObject: JsonDictionary,
-        reduceJSFunction: String,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationCustomResult<T>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationCustomResult<T>], Swift.Error>> {
-        return group(
-            keys: keys,
-            initialObject: initialObject,
-            reduceJSFunction: reduceJSFunction,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
     }
     
     @discardableResult
@@ -691,80 +306,6 @@ open class DataStore<T: Persistable> where T: NSObject {
         }
     }
     
-    /**
-     Count aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - countType: Integer type to be return as a result count
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(count:countType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Count: CountType>(
-        count keys: [String],
-        countType: Count.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationCountResult<T, Count>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationCountResult<T, Count>], Swift.Error>> {
-        return group(
-            count: keys,
-            countType: countType,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationCountResult<T, Count>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Count aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - countType: Integer type to be return as a result count
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(count:countType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Count: CountType>(
-        count keys: [String],
-        countType: Count.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationCountResult<T, Count>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationCountResult<T, Count>], Swift.Error>> {
-        return group(
-            count: keys,
-            countType: countType,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
     @discardableResult
     open func group<Count: CountType>(
         count keys: [String],
@@ -817,86 +358,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
             return nil
         }
-    }
-    
-    /**
-     Sum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - sum: Property name used in the sum operation
-       - sumType: Integer type to be return as a result sum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:sum:sumType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Sum: AddableType>(
-        keys: [String],
-        sum: String,
-        sumType: Sum.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationSumResult<T, Sum>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationSumResult<T, Sum>], Swift.Error>> {
-        return group(
-            keys: keys,
-            sum: sum,
-            sumType: sumType,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationSumResult<T, Sum>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Sum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - sum: Property name used in the sum operation
-       - sumType: Integer type to be return as a result sum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:sum:sumType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Sum: AddableType>(
-        keys: [String],
-        sum: String,
-        sumType: Sum.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationSumResult<T, Sum>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationSumResult<T, Sum>], Swift.Error>> {
-        return group(
-            keys: keys,
-            sum: sum,
-            sumType: sumType,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
     }
     
     @discardableResult
@@ -954,86 +415,6 @@ open class DataStore<T: Persistable> where T: NSObject {
         }
     }
     
-    /**
-     Average aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - avg: Property name used in the average operation
-       - avgType: Integer type to be return as a result average
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:avg:avgType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Avg: AddableType>(
-        keys: [String],
-        avg: String,
-        avgType: Avg.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationAvgResult<T, Avg>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationAvgResult<T, Avg>], Swift.Error>> {
-        return group(
-            keys: keys,
-            avg: avg,
-            avgType: avgType,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationAvgResult<T, Avg>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Average aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - avg: Property name used in the average operation
-       - avgType: Integer type to be return as a result average
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:avg:avgType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Avg: AddableType>(
-        keys: [String],
-        avg: String,
-        avgType: Avg.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationAvgResult<T, Avg>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationAvgResult<T, Avg>], Swift.Error>> {
-        return group(
-            keys: keys,
-            avg: avg,
-            avgType: avgType,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
     @discardableResult
     open func group<Avg: AddableType>(
         keys: [String],
@@ -1089,86 +470,6 @@ open class DataStore<T: Persistable> where T: NSObject {
         }
     }
     
-    /**
-     Minimum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - min: Property name used in the minimum operation
-       - minType: Integer type to be return as a result minimum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:min:minType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Min: MinMaxType>(
-        keys: [String],
-        min: String,
-        minType: Min.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationMinResult<T, Min>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationMinResult<T, Min>], Swift.Error>> {
-        return group(
-            keys: keys,
-            min: min,
-            minType: minType,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationMinResult<T, Min>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Minimum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - min: Property name used in the minimum operation
-       - minType: Integer type to be return as a result minimum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:min:minType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Min: MinMaxType>(
-        keys: [String],
-        min: String,
-        minType: Min.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationMinResult<T, Min>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationMinResult<T, Min>], Swift.Error>> {
-        return group(
-            keys: keys,
-            min: min,
-            minType: minType,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
     @discardableResult
     open func group<Min: MinMaxType>(
         keys: [String],
@@ -1222,86 +523,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
             return nil
         }
-    }
-    
-    /**
-     Maximum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - max: Property name used in the maximum operation
-       - maxType: Integer type to be return as a result maximum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:max:maxType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Max: MinMaxType>(
-        keys: [String],
-        max: String,
-        maxType: Max.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping ([AggregationMaxResult<T, Max>]?, Swift.Error?) -> Void
-    ) -> AnyRequest<Result<[AggregationMaxResult<T, Max>], Swift.Error>> {
-        return group(
-            keys: keys,
-            max: max,
-            maxType: maxType,
-            condition: condition,
-            readPolicy: readPolicy
-        ) { (result: Result<[AggregationMaxResult<T, Max>], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                completionHandler(results, nil)
-            case .failure(let error):
-                completionHandler(nil, error)
-            }
-        }
-    }
-    
-    /**
-     Maximum aggregation function.
-     Note: this function does not work on local data. It must be run against the
-     backend.
-     - Parameters:
-       - keys: Property names that should be grouped
-       - max: Property name used in the maximum operation
-       - maxType: Integer type to be return as a result maximum
-       - condition: (Optional) Predicate that filter the records to be
-     considered during the reduce function. Default value: `nil`
-       - readPolicy: (Optional) Enforces a different `ReadPolicy` otherwise use
-     the client's `ReadPolicy`. Default value: `nil`
-       - completionHandler: Completion handler to be called once the
-     response returns
-     - returns: A `Request` instance which will allow cancel the request later
-     */
-    @available(*, deprecated: 3.6.0, message: "Please use group(keys:max:maxType:condition:options:completionHandler:)")
-    @discardableResult
-    open func group<Max: MinMaxType>(
-        keys: [String],
-        max: String,
-        maxType: Max.Type? = nil,
-        condition: NSPredicate? = nil,
-        readPolicy: ReadPolicy? = nil,
-        completionHandler: @escaping (Result<[AggregationMaxResult<T, Max>], Swift.Error>) -> Void
-    ) -> AnyRequest<Result<[AggregationMaxResult<T, Max>], Swift.Error>> {
-        return group(
-            keys: keys,
-            max: max,
-            maxType: maxType,
-            condition: condition,
-            options: Options(
-                readPolicy: readPolicy
-            ),
-            completionHandler: completionHandler
-        )
     }
     
     @discardableResult
@@ -1360,44 +581,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /// Creates or updates a record.
-    @available(*, deprecated: 3.6.0, message: "Please use save(_:options:completionHandler:) instead")
-    @discardableResult
-    open func save(
-        _ persistable: T,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ObjectCompletionHandler? = nil
-    ) -> AnyRequest<Result<T, Swift.Error>> {
-        return save(
-            persistable,
-            writePolicy: writePolicy
-        ) { (result: Result<T, Swift.Error>) in
-            switch result {
-            case .success(let obj):
-                completionHandler?(obj, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Creates or updates a record.
-    @available(*, deprecated: 3.6.0, message: "Please use save(_:options:completionHandler:) instead")
-    @discardableResult
-    open func save(
-        _ persistable: T,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<T, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<T, Swift.Error>> {
-        return save(
-            persistable,
-            options: Options(
-                writePolicy: writePolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Creates or updates a record.
     @discardableResult
     open func save(
         _ persistable: T,
@@ -1421,44 +604,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /// Deletes a record.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        _ persistable: T,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) throws -> AnyRequest<Result<Int, Swift.Error>> {
-        return try remove(
-            persistable,
-            writePolicy: writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes a record.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        _ persistable: T,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) throws -> AnyRequest<Result<Int, Swift.Error>> {
-        return try remove(
-            persistable,
-            options: Options(
-                writePolicy: writePolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a record.
     @discardableResult
     open func remove(
         _ persistable: T,
@@ -1477,112 +622,16 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /// Deletes a list of records.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
     @discardableResult
-    open func remove(
-        _ array: [T],
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            array,
-            writePolicy: writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes a list of records.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        _ array: [T],
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            array,
-            options: Options(
-                writePolicy: writePolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a list of records.
-    @discardableResult
-    open func remove(
-        _ array: [T],
+    open func remove<S: Sequence>(
+        _ array: S,
         options: Options? = nil,
         completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        var ids: [String] = []
-        for persistable in array {
-            if let id = persistable.entityId {
-                ids.append(id)
-            }
-        }
+    ) -> AnyRequest<Result<Int, Swift.Error>> where S.Element == T {
+        let ids = array.compactMap { $0.entityId }
         return remove(
             byIds: ids,
             options: options,
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a record using the `_id` of the record.
-    @discardableResult
-    @available(*, deprecated: 3.4.0, message: "Please use `remove(byId:)` instead")
-    open func removeById(
-        _ id: String,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byId: id,
-            writePolicy: writePolicy,
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a record using the `_id` of the record.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(byId:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        byId id: String,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byId: id,
-            writePolicy: writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes a record using the `_id` of the record.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(byId:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        byId id: String,
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byId: id,
-            options: Options(
-                writePolicy: writePolicy
-            ),
             completionHandler: completionHandler
         )
     }
@@ -1616,59 +665,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Deletes a list of records using the `_id` of the records.
     @discardableResult
-    @available(*, deprecated: 3.4.0, message: "Please use `remove(byIds:)` instead")
-    open func removeById(
-        _ ids: [String],
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byIds: ids,
-            writePolicy: writePolicy,
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a list of records using the `_id` of the records.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(byIds:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        byIds ids: [String],
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byIds: ids,
-            writePolicy: writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes a list of records using the `_id` of the records.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(byIds:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        byIds ids: [String],
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            byIds: ids,
-            options: Options(
-                writePolicy: writePolicy
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a list of records using the `_id` of the records.
-    @discardableResult
     open func remove(
         byIds ids: [String],
         options: Options? = nil,
@@ -1685,44 +681,6 @@ open class DataStore<T: Persistable> where T: NSObject {
         return remove(
             query,
             options: options,
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a list of records that matches with the query passed by parameter.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        _ query: Query = Query(),
-        writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            query,
-            writePolicy: writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes a list of records that matches with the query passed by parameter.
-    @available(*, deprecated: 3.6.0, message: "Please use remove(_:options:completionHandler:) instead")
-    @discardableResult
-    open func remove(
-        _ query: Query = Query(),
-        writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return remove(
-            query,
-            options: Options(
-                writePolicy: writePolicy
-            ),
             completionHandler: completionHandler
         )
     }
@@ -1748,40 +706,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
         }
         return request
-    }
-    
-    /// Deletes all the records.
-    @available(*, deprecated: 3.6.0, message: "Please use removeAll(options:completionHandler:) instead")
-    @discardableResult
-    open func removeAll(
-        _ writePolicy: WritePolicy? = nil,
-        completionHandler: IntCompletionHandler?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return removeAll(
-            writePolicy
-        ) { (result: Result<Int, Swift.Error>) in
-            switch result {
-            case .success(let count):
-                completionHandler?(count, nil)
-            case .failure(let error):
-                completionHandler?(nil, error)
-            }
-        }
-    }
-    
-    /// Deletes all the records.
-    @available(*, deprecated: 3.6.0, message: "Please use removeAll(options:completionHandler:) instead")
-    @discardableResult
-    open func removeAll(
-        _ writePolicy: WritePolicy? = nil,
-        completionHandler: ((Result<Int, Swift.Error>) -> Void)?
-    ) -> AnyRequest<Result<Int, Swift.Error>> {
-        return removeAll(
-            options: Options(
-                writePolicy: writePolicy
-            ),
-            completionHandler: completionHandler
-        )
     }
     
     /// Deletes all the records.
@@ -1888,53 +812,6 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
     
     /// Gets the records from the backend that matches with the query passed by parameter and saves locally in the local cache.
-    @available(*, deprecated: 3.7.0, message: "Please use AnyRandomAccessCollection<T> instead of Array<T> (or [T]) for completion handlers")
-    @discardableResult
-    open func pull(
-        _ query: Query = Query(),
-        deltaSet: Bool? = nil,
-        deltaSetCompletionHandler: (([T]) -> Void)? = nil,
-        completionHandler: ((Result<[T], Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<[T], Swift.Error>> {
-        let request = pull(
-            query,
-            deltaSetCompletionHandler: {
-                guard let deltaSetCompletionHandler = deltaSetCompletionHandler else {
-                    return
-                }
-                
-                let _ = $1
-                deltaSetCompletionHandler(Array($0))
-            },
-            options: Options(
-                deltaSet: deltaSet
-            )
-        ) { (result: Result<AnyRandomAccessCollection<T>, Swift.Error>) in
-            guard let completionHandler = completionHandler else {
-                return
-            }
-            
-            switch result {
-            case .success(let results):
-                completionHandler(.success(Array(results)))
-            case .failure(let error):
-                completionHandler(.failure(error))
-            }
-        }
-        return AnyRequest(request) {
-            if let result = $0 {
-                switch result {
-                case .success(let results):
-                    return .success(Array(results))
-                case .failure(let error):
-                    return .failure(error)
-                }
-            }
-            return nil
-        }
-    }
-    
-    /// Gets the records from the backend that matches with the query passed by parameter and saves locally in the local cache.
     @discardableResult
     open func pull(
         _ query: Query = Query(),
@@ -2023,44 +900,6 @@ open class DataStore<T: Persistable> where T: NSObject {
             options: Options(
                 deltaSet: deltaSet
             )
-        ) { (result: Result<(UInt, AnyRandomAccessCollection<T>), [Swift.Error]>) in
-            guard let completionHandler = completionHandler else {
-                return
-            }
-            
-            switch result {
-            case .success(let count, let results):
-                completionHandler(.success((count, Array(results))))
-            case .failure(let error):
-                completionHandler(.failure(error))
-            }
-        }
-        return AnyRequest(request) {
-            if let result = $0 {
-                switch result {
-                case .success(let count, let results):
-                    return .success((count, Array(results)))
-                case .failure(let error):
-                    return .failure(error)
-                }
-            }
-            return nil
-        }
-    }
-    
-    /// Calls `push` and then `pull` methods, so it sends all the pending records in the local cache and then gets the records from the backend and saves locally in the local cache.
-    @available(*, deprecated: 3.7.0, message: "Please use AnyRandomAccessCollection<T> instead of Array<T> (or [T]) for completion handlers")
-    @discardableResult
-    open func sync(
-        _ query: Query = Query(),
-        deltaSetCompletionHandler: ((AnyRandomAccessCollection<T>, AnyRandomAccessCollection<T>) -> Void)? = nil,
-        options: Options? = nil,
-        completionHandler: ((Result<(UInt, [T]), [Swift.Error]>) -> Void)? = nil
-    ) -> AnyRequest<Result<(UInt, [T]), [Swift.Error]>> {
-        let request = sync(
-            query,
-            deltaSetCompletionHandler: deltaSetCompletionHandler,
-            options: options
         ) { (result: Result<(UInt, AnyRandomAccessCollection<T>), [Swift.Error]>) in
             guard let completionHandler = completionHandler else {
                 return

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -20,10 +20,19 @@ func *(lhs: NSDecimalNumber, rhs: NSDecimalNumber) -> NSDecimalNumber {
 /// Class to interact with a specific collection in the backend.
 open class DataStore<T: Persistable> where T: NSObject {
     
+    @available(*, deprecated: 3.17.0, message: "Please use Result<AnyRandomAccessCollection<T>, Swift.Error> instead")
     public typealias ArrayCompletionHandler = ([T]?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<T, Swift.Error> instead")
     public typealias ObjectCompletionHandler = (T?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<Int, Swift.Error> instead")
     public typealias IntCompletionHandler = (Int?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<UInt, [Swift.Error]> instead")
     public typealias UIntErrorTypeArrayCompletionHandler = (UInt?, [Swift.Error]?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<(Int, AnyRandomAccessCollection<T>), [Swift.Error]> instead")
     public typealias UIntArrayCompletionHandler = (UInt?, [T]?, [Swift.Error]?) -> Void
     
     fileprivate let readPolicy: ReadPolicy
@@ -271,7 +280,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationCustomResult<T>] in
             let array = results.map { (json) -> AggregationCustomResult<T> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationCustomResult<T>(
                     value: T(JSON: json)!,
                     custom: json
@@ -327,7 +336,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationCountResult<T, Count>] in
             let array = results.map { (json) -> AggregationCountResult<T, Count> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationCountResult<T, Count>(
                     value: T(JSON: json)!,
                     count: json[aggregation.resultKey] as! Count
@@ -382,7 +391,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationSumResult<T, Sum>] in
             let array = results.map { (json) -> AggregationSumResult<T, Sum> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationSumResult<T, Sum>(
                     value: T(JSON: json)!,
                     sum: json[aggregation.resultKey] as! Sum
@@ -437,7 +446,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationAvgResult<T, Avg>] in
             let array = results.map { (json) -> AggregationAvgResult<T, Avg> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationAvgResult<T, Avg>(
                     value: T(JSON: json)!,
                     avg: json[aggregation.resultKey] as! Avg
@@ -492,7 +501,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationMinResult<T, Min>] in
             let array = results.map { (json) -> AggregationMinResult<T, Min> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationMinResult<T, Min>(
                     value: T(JSON: json)!,
                     min: json[aggregation.resultKey] as! Min
@@ -547,7 +556,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         let convert = { (results: [JsonDictionary]) -> [AggregationMaxResult<T, Max>] in
             let array = results.map { (json) -> AggregationMaxResult<T, Max> in
                 var json = json
-                json[Entity.Key.entityId] = groupId
+                json[Entity.CodingKeys.entityId] = groupId
                 return AggregationMaxResult<T, Max>(
                     value: T(JSON: json)!,
                     max: json[aggregation.resultKey] as! Max
@@ -722,6 +731,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Sends to the backend all the pending records in the local cache.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.push(options:completionHandler:) instead")
     open func push(
         timeout: TimeInterval? = nil,
         completionHandler: UIntErrorTypeArrayCompletionHandler? = nil
@@ -740,6 +750,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Sends to the backend all the pending records in the local cache.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.push(options:completionHandler:) instead")
     open func push(
         timeout: TimeInterval? = nil,
         completionHandler: ((Result<UInt, [Swift.Error]>) -> Void)? = nil
@@ -789,6 +800,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Gets the records from the backend that matches with the query passed by parameter and saves locally in the local cache.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.pull(_:deltaSetCompletionHandler:options:completionHandler:) instead")
     open func pull(
         _ query: Query = Query(),
         deltaSetCompletionHandler: ((AnyRandomAccessCollection<T>, AnyRandomAccessCollection<T>) -> Void)? = nil,
@@ -866,6 +878,8 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Calls `push` and then `pull` methods, so it sends all the pending records in the local cache and then gets the records from the backend and saves locally in the local cache.
     @discardableResult
+    
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.sync(_:deltaSetCompletionHandler:options:completionHandler:) instead")
     open func sync(
         _ query: Query = Query(),
         deltaSetCompletionHandler: ((AnyRandomAccessCollection<T>, AnyRandomAccessCollection<T>) -> Void)? = nil,
@@ -888,6 +902,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Calls `push` and then `pull` methods, so it sends all the pending records in the local cache and then gets the records from the backend and saves locally in the local cache.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.sync(_:deltaSetCompletionHandler:options:completionHandler:) instead")
     open func sync(
         _ query: Query = Query(),
         deltaSetCompletionHandler: ((AnyRandomAccessCollection<T>, AnyRandomAccessCollection<T>) -> Void)? = nil,
@@ -977,6 +992,7 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Deletes all the pending changes in the local cache.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use DataStore.purge(_:options:completionHandler:) instead")
     open func purge(
         _ query: Query = Query(),
         completionHandler: DataStore<T>.IntCompletionHandler? = nil

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -11,18 +11,6 @@ import Realm
 import RealmSwift
 import ObjectMapper
 
-/// Key to map the `_id` column in your Persistable implementation class.
-@available(*, deprecated: 3.5.2, message: "Please use Entity.Key.entityId instead")
-public let PersistableIdKey = "_id"
-
-/// Key to map the `_acl` column in your Persistable implementation class.
-@available(*, deprecated: 3.5.2, message: "Please use Entity.Key.acl instead")
-public let PersistableAclKey = "_acl"
-
-/// Key to map the `_kmd` column in your Persistable implementation class.
-@available(*, deprecated: 3.5.2, message: "Please use Entity.Key.metadata instead")
-public let PersistableMetadataKey = "_kmd"
-
 public typealias List<T: RealmSwift.Object> = RealmSwift.List<T>
 public typealias Object = RealmSwift.Object
 
@@ -51,15 +39,19 @@ public enum ObjectChange<T: Entity> {
 open class Entity: Object, Persistable {
     
     /// Property names for the `Entity` class
+    @available(*, deprecated: 3.17.0, message: "Please use Entity.CodingKeys instead")
     public struct Key {
         
         /// Key to map the `_id` column in your Persistable implementation class.
+        @available(*, deprecated: 3.17.0, message: "Please use Entity.CodingKeys.entityId instead")
         public static let entityId = "_id"
         
         /// Key to map the `_acl` column in your Persistable implementation class.
+        @available(*, deprecated: 3.17.0, message: "Please use Entity.CodingKeys.acl instead")
         public static let acl = "_acl"
         
         /// Key to map the `_kmd` column in your Persistable implementation class.
+        @available(*, deprecated: 3.17.0, message: "Please use Entity.CodingKeys.metadata instead")
         public static let metadata = "_kmd"
         
     }
@@ -72,7 +64,7 @@ open class Entity: Object, Persistable {
                 return nil
             }
         } else {
-            guard let entityId: String = map[Key.entityId].value(), !entityId.isEmpty else {
+            guard let entityId: String = map[CodingKeys.entityId].value(), !entityId.isEmpty else {
                 log.error("_id is required")
                 return nil
             }
@@ -124,9 +116,9 @@ open class Entity: Object, Persistable {
     
     /// Override this method to tell how to map your own objects.
     open func propertyMapping(_ map: Map) {
-        entityId <- ("entityId", map[Key.entityId])
-        metadata <- ("metadata", map[Key.metadata])
-        acl <- ("acl", map[Key.acl])
+        entityId <- ("entityId", map[CodingKeys.entityId])
+        metadata <- ("metadata", map[CodingKeys.metadata])
+        acl <- ("acl", map[CodingKeys.acl])
     }
     
     /**
@@ -180,6 +172,28 @@ open class Entity: Object, Persistable {
         } else {
             self.propertyMapping(map)
         }
+    }
+    
+}
+
+extension Entity {
+    
+    /// Property names for the `Entity` class
+    public enum CodingKeys: String, CodingKey {
+        
+        /// Key to map the `_id` column in your Persistable implementation class.
+        case entityId = "_id"
+        
+        /// Key to map the `_acl` column in your Persistable implementation class.
+        case acl = "_acl"
+        
+        /// Key to map the `_kmd` column in your Persistable implementation class.
+        case metadata = "_kmd"
+        
+    }
+    
+    public subscript<Key: RawRepresentable>(key: Key) -> Any? where Key.RawValue == String {
+        return self[key.rawValue]
     }
     
 }

--- a/Kinvey/Kinvey/File.swift
+++ b/Kinvey/Kinvey/File.swift
@@ -133,9 +133,9 @@ open class File: Object, Mappable {
     }
     
     open func mapping(map: Map) {
-        fileId <- map[Entity.Key.entityId]
-        acl <- map[Entity.Key.acl]
-        metadata <- map[Entity.Key.metadata]
+        fileId <- map[Entity.CodingKeys.entityId]
+        acl <- map[Entity.CodingKeys.acl]
+        metadata <- map[Entity.CodingKeys.metadata]
         publicAccessible <- map["_public"]
         fileName <- map["_filename"]
         mimeType <- map["mimeType"]

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -72,10 +72,19 @@ public enum ImageRepresentation {
 /// Class to interact with the `Files` collection in the backend.
 open class FileStore<FileType: File> {
     
+    @available(*, deprecated: 3.17.0, message: "Please use Result<FileType, Swift.Error> instead")
     public typealias FileCompletionHandler = (FileType?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<(FileType, Data), Swift.Error> instead")
     public typealias FileDataCompletionHandler = (FileType?, Data?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<(FileType, URL), Swift.Error> instead")
     public typealias FilePathCompletionHandler = (FileType?, URL?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<UInt, Swift.Error> instead")
     public typealias UIntCompletionHandler = (UInt?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<[FileType], Swift.Error> instead")
     public typealias FileArrayCompletionHandler = ([FileType]?, Swift.Error?) -> Void
     
     internal let client: Client
@@ -159,6 +168,7 @@ open class FileStore<FileType: File> {
 
     /// Uploads a `UIImage` in a PNG or JPEG format.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:image:imageRepresentation:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         image: UIImage,
@@ -183,6 +193,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a `UIImage` in a PNG or JPEG format.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:image:imageRepresentation:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         image: UIImage,
@@ -224,6 +235,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using the file path.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:path:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         path: String,
@@ -246,6 +258,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using the file path.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:path:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         path: String,
@@ -280,6 +293,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using a input stream.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:stream:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         stream: InputStream,
@@ -302,6 +316,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using a input stream.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:stream:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         stream: InputStream,
@@ -369,6 +384,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using a `NSData`.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:data:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         data: Data,
@@ -391,6 +407,7 @@ open class FileStore<FileType: File> {
     
     /// Uploads a file using a `NSData`.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.upload(_:data:options:completionHandler:) instead")
     open func upload(
         _ file: FileType,
         data: Data,
@@ -758,6 +775,7 @@ open class FileStore<FileType: File> {
     
     /// Refresh a `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.refresh(_:options:completionHandler:) instead")
     open func refresh(
         _ file: FileType,
         ttl: TTL? = nil,
@@ -778,6 +796,7 @@ open class FileStore<FileType: File> {
     
     /// Refresh a `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.refresh(_:options:completionHandler:) instead")
     open func refresh(
         _ file: FileType,
         ttl: TTL? = nil,
@@ -913,6 +932,7 @@ open class FileStore<FileType: File> {
     
     /// Downloads a file using the `downloadURL` of the `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.download(_:storeType:options:completionHandler:) instead")
     open func download(
         _ file: FileType,
         storeType: StoreType = .cache,
@@ -935,6 +955,7 @@ open class FileStore<FileType: File> {
     
     /// Downloads a file using the `downloadURL` of the `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.download(_:storeType:options:completionHandler:) instead")
     open func download(
         _ file: FileType,
         storeType: StoreType = .cache,
@@ -1026,6 +1047,7 @@ open class FileStore<FileType: File> {
     
     /// Downloads a file using the `downloadURL` of the `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.download(_:options:completionHandler:) instead")
     open func download(
         _ file: FileType,
         ttl: TTL? = nil,
@@ -1053,6 +1075,7 @@ open class FileStore<FileType: File> {
     
     /// Downloads a file using the `downloadURL` of the `File` instance.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.download(_:options:completionHandler:) instead")
     open func download(
         _ file: FileType,
         ttl: TTL? = nil,
@@ -1150,6 +1173,7 @@ open class FileStore<FileType: File> {
     
     /// Deletes a file instance in the backend.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.remove(_:options:completionHandler:) instead")
     open func remove(
         _ file: FileType,
         completionHandler: UIntCompletionHandler? = nil
@@ -1169,6 +1193,7 @@ open class FileStore<FileType: File> {
     
     /// Deletes a file instance in the backend.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.remove(_:options:completionHandler:) instead")
     open func remove(
         _ file: FileType,
         completionHandler: ((Result<UInt, Swift.Error>) -> Void)? = nil
@@ -1217,6 +1242,7 @@ open class FileStore<FileType: File> {
     
     /// Gets a list of files that matches with the query passed by parameter.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.find(_:options:completionHandler:) instead")
     open func find(
         _ query: Query = Query(),
         ttl: TTL? = nil,
@@ -1237,6 +1263,7 @@ open class FileStore<FileType: File> {
     
     /// Gets a list of files that matches with the query passed by parameter.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use FileStore.find(_:options:completionHandler:) instead")
     open func find(
         _ query: Query = Query(),
         ttl: TTL? = nil,

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -81,18 +81,6 @@ open class FileStore<FileType: File> {
     internal let client: Client
     internal let cache: AnyFileCache<FileType>?
     
-    /// Factory method that returns a `FileStore`.
-    @available(*, deprecated: 3.5.2, message: "Please use the constructor instead")
-    open class func getInstance<FileType: File>(client: Client = sharedClient) -> FileStore<FileType> {
-        return FileStore<FileType>(client: client)
-    }
-    
-    /// Factory method that returns a `FileStore`.
-    @available(*, deprecated: 3.5.2, message: "Please use the constructor instead")
-    open class func getInstance<FileType: File>(fileType: FileType.Type, client: Client = sharedClient) -> FileStore<FileType> {
-        return FileStore<FileType>(client: client)
-    }
-    
     /**
      Constructor that takes a specific `Client` instance or use the
      `sharedClient` instance

--- a/Kinvey/Kinvey/FindOperation.swift
+++ b/Kinvey/Kinvey/FindOperation.swift
@@ -93,8 +93,6 @@ internal class FindOperation<T: Persistable>: ReadOperation<T, AnyRandomAccessCo
         return AnyRequest(request)
     }
     
-    typealias ArrayCompletionHandler = ([Any]?, Error?) -> Void
-    
     private func count(multiRequest: MultiRequest<ResultType>) -> Promise<Int?> {
         return Promise<Int?> { resolver in
             if !deltaSet, autoPagination {

--- a/Kinvey/Kinvey/GetOperation.swift
+++ b/Kinvey/Kinvey/GetOperation.swift
@@ -57,7 +57,7 @@ internal class GetOperation<T: Persistable>: ReadOperation<T, T, Swift.Error>, R
             if let response = response,
                 response.isOK,
                 let json = self.client.responseParser.parse(data),
-                json[Entity.Key.entityId] != nil,
+                json[Entity.CodingKeys.entityId] != nil,
                 let obj = T(JSON: json)
             {
                 self.cache?.save(entity: obj)

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -424,11 +424,12 @@ internal class HttpRequest<Result>: TaskProgressRequest, Request {
                     let kinveyAuthToken = socialIdentity.kinvey,
                     let refreshToken = kinveyAuthToken["refresh_token"] as? String
                 {
-                    MIC.login(refreshToken: refreshToken, authServiceId: self.client.clientId) { user, error in
-                        if let user = user {
+                    MIC.login(refreshToken: refreshToken, authServiceId: self.client.clientId, options: self.options) {
+                        switch $0 {
+                        case .success(let user):
                             self.credential = user
                             self.execute(urlSession: urlSession, completionHandler)
-                        } else {
+                        case .failure(let error):
                             if let error = error as? Kinvey.Error {
                                 switch error {
                                 case .invalidCredentials:

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -369,7 +369,7 @@ class HttpRequestFactory: RequestFactory {
     ) -> HttpRequest<Result> {
         let collectionName = T.collectionName()
         var bodyObject = persistable.toJSON()
-        let objId = bodyObject[Entity.Key.entityId] as? String
+        let objId = bodyObject[Entity.CodingKeys.entityId] as? String
         let isNewObj = objId == nil || objId!.hasPrefix(ObjectIdTmpPrefix)
         let request = HttpRequest<Result>(
             httpMethod: isNewObj ? .post : .put,
@@ -379,7 +379,7 @@ class HttpRequestFactory: RequestFactory {
         )
         
         if (isNewObj) {
-            bodyObject[Entity.Key.entityId] = nil
+            bodyObject[Entity.CodingKeys.entityId] = nil
         }
         
         request.setBody(json: bodyObject)

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -257,7 +257,7 @@ func buildError(
     } else if let response = response,
         response.isOK,
         let json = client.responseParser.parse(data),
-        json[Entity.Key.entityId] == nil
+        json[Entity.CodingKeys.entityId] == nil
     {
         return Error.objectIdMissing
     } else if let response = response,

--- a/Kinvey/Kinvey/MIC.swift
+++ b/Kinvey/Kinvey/MIC.swift
@@ -266,10 +266,11 @@ open class MIC {
     class func login<U: User>(
         refreshToken: String,
         authServiceId: String?,
-        client: Client = sharedClient,
-        completionHandler: User.UserHandler<U>? = nil
+        options: Options?,
+        completionHandler: ((Result<U, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<U, Swift.Error>> {
         let requests = MultiRequest<Result<U, Swift.Error>>()
+        let client = options?.client ?? sharedClient
         let request = client.networkRequestFactory.buildOAuthGrantRefreshToken(
             refreshToken: refreshToken,
             options: Options(
@@ -278,9 +279,9 @@ open class MIC {
         )
         request.execute { (data, response, error) in
             if let response = response, response.isOK, let authData = client.responseParser.parse(data) {
-                requests += User.login(authSource: .kinvey, authData, client: client, completionHandler: completionHandler)
+                requests += User.login(authSource: .kinvey, authData, options: options, completionHandler: completionHandler)
             } else {
-                completionHandler?(nil, buildError(data, response, error, client))
+                completionHandler?(.failure(buildError(data, response, error, client)))
             }
         }
         requests += request

--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -14,31 +14,24 @@ import ObjectMapper
 /// This class represents the metadata information for a record
 public class Metadata: Object, Mappable {
     
-    /// Last Modification Time Key.
-    @available(*, deprecated: 3.5.2, message: "Please use Metadata.Key.lastModifiedTime instead")
-    open static let LmtKey = "lmt"
-    
-    /// Entity Creation Time Key.
-    @available(*, deprecated: 3.5.2, message: "Please use Metadata.Key.entityCreationTime instead")
-    open static let EctKey = "ect"
-    
-    /// Authentication Token Key.
-    @available(*, deprecated: 3.5.2, message: "Please use Metadata.Key.authToken instead")
-    open static let AuthTokenKey = "authtoken"
-    
     /// Property names for `Metadata`
+    @available(*, deprecated: 3.17.0, message: "Please use Metadata.CodingKeys instead")
     public struct Key {
         
         /// Last Modification Time Key.
+        @available(*, deprecated: 3.17.0, message: "Please use Metadata.CodingKeys.lastModifiedTime instead")
         public static let lastModifiedTime = "lmt"
         
         /// Entity Creation Time Key.
+        @available(*, deprecated: 3.17.0, message: "Please use Metadata.CodingKeys.entityCreationTime instead")
         public static let entityCreationTime = "ect"
         
         /// Authentication Token Key.
+        @available(*, deprecated: 3.17.0, message: "Please use Metadata.CodingKeys.authtoken instead")
         public static let authtoken = "authtoken"
         
         /// Last Read Time Key.
+        @available(*, deprecated: 3.17.0, message: "Please use Metadata.CodingKeys.lastReadTime instead")
         internal static let lastReadTime = "lrt"
     
     }
@@ -128,6 +121,27 @@ public class Metadata: Object, Mappable {
         super.init(value: value, schema: schema)
     }
 
+}
+
+extension Metadata {
+    
+    /// Property names for `Metadata`
+    public enum CodingKeys: String, CodingKey {
+        
+        /// Last Modification Time Key.
+        case lastModifiedTime = "lmt"
+        
+        /// Entity Creation Time Key.
+        case entityCreationTime = "ect"
+        
+        /// Authentication Token Key.
+        case authtoken = "authtoken"
+        
+        /// Last Read Time Key.
+        case lastReadTime = "lrt"
+        
+    }
+    
 }
 
 /// Metadata information for each `User`

--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -98,9 +98,9 @@ public class Metadata: Object, Mappable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     public func mapping(map: Map) {
-        lmt <- map[Key.lastModifiedTime]
-        ect <- map[Key.entityCreationTime]
-        authtoken <- map[Key.authtoken]
+        lmt <- map[CodingKeys.lastModifiedTime]
+        ect <- map[CodingKeys.entityCreationTime]
+        authtoken <- map[CodingKeys.authtoken]
     }
     
     // MARK: Realm

--- a/Kinvey/Kinvey/Operation.swift
+++ b/Kinvey/Kinvey/Operation.swift
@@ -107,11 +107,6 @@ class CollectionBlockOperation: BlockOperation {
 
 internal class Operation<T: Persistable>: NSObject where T: NSObject {
     
-    typealias ArrayCompletionHandler = ([T]?, Swift.Error?) -> Void
-    typealias ObjectCompletionHandler = (T?, Swift.Error?) -> Void
-    typealias UIntCompletionHandler = (UInt?, Swift.Error?) -> Void
-    typealias UIntArrayCompletionHandler = (UInt?, [T]?, Swift.Error?) -> Void
-    
     let cache: AnyCache<T>?
     let options: Options?
     let client: Client
@@ -128,9 +123,9 @@ internal class Operation<T: Persistable>: NSObject where T: NSObject {
     func reduceToIdsLmts(_ jsonArray: [JsonDictionary]) -> [String : String] {
         var items = [String : String](minimumCapacity: jsonArray.count)
         for json in jsonArray {
-            if let id = json[Entity.Key.entityId] as? String,
-                let kmd = json[Entity.Key.metadata] as? JsonDictionary,
-                let lmt = kmd[Metadata.Key.lastModifiedTime] as? String
+            if let id = json[Entity.CodingKeys.entityId] as? String,
+                let kmd = json[Entity.CodingKeys.metadata] as? JsonDictionary,
+                let lmt = kmd[Metadata.CodingKeys.lastModifiedTime] as? String
             {
                 items[id] = lmt
             }

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -476,16 +476,16 @@ extension Persistable {
             properties!.append(key)
             results[value] = properties
         }
-        let entityIdMapped = results[Entity.Key.entityId] != nil
-        let metadataMapped = results[Entity.Key.metadata] != nil
+        let entityIdMapped = results[Entity.CodingKeys.entityId] != nil
+        let metadataMapped = results[Entity.CodingKeys.metadata] != nil
         if !(entityIdMapped && metadataMapped) {
             let isEntity = self is Entity.Type
             let hintMessage = isEntity ? "Please call super.propertyMapping() inside your propertyMapping() method." : "Please add properties in your Persistable model class to map the missing properties."
             guard entityIdMapped else {
-                fatalError("Property \(Entity.Key.entityId) (Entity.Key.entityId) is missing in the propertyMapping() method. \(hintMessage)")
+                fatalError("Property \(Entity.CodingKeys.entityId) (Entity.Key.entityId) is missing in the propertyMapping() method. \(hintMessage)")
             }
             guard metadataMapped else {
-                fatalError("Property \(Entity.Key.metadata) (Entity.Key.metadata) is missing in the propertyMapping() method. \(hintMessage)")
+                fatalError("Property \(Entity.CodingKeys.metadata) (Entity.Key.metadata) is missing in the propertyMapping() method. \(hintMessage)")
             }
         }
         return results
@@ -506,15 +506,15 @@ extension Persistable {
     }
     
     internal static func entityIdProperty() -> String {
-        return propertyMappingReverse()[Entity.Key.entityId]!.last!
+        return propertyMappingReverse()[Entity.CodingKeys.entityId]!.last!
     }
     
     internal static func aclProperty() -> String? {
-        return propertyMappingReverse()[Entity.Key.acl]?.last
+        return propertyMappingReverse()[Entity.CodingKeys.acl]?.last
     }
     
     internal static func metadataProperty() -> String? {
-        return propertyMappingReverse()[Entity.Key.metadata]?.last
+        return propertyMappingReverse()[Entity.CodingKeys.metadata]?.last
     }
     
 }

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -576,3 +576,24 @@ extension AnyRandomAccessCollection where Element: Persistable {
     }
     
 }
+
+extension Map {
+    
+    public subscript<Key: RawRepresentable>(key: Key) -> Map where Key.RawValue == String {
+        return self[key.rawValue]
+    }
+    
+}
+
+extension Dictionary where Key == String {
+    
+    public subscript<Key: RawRepresentable>(key: Key) -> Value? where Key.RawValue == String {
+        get {
+            return self[key.rawValue]
+        }
+        set {
+            self[key.rawValue] = newValue
+        }
+    }
+    
+}

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -765,7 +765,7 @@ extension RealmCache: DynamicCacheType {
             if let property = properties[translatedKey],
                 property.type == .object,
                 let objectClassName = property.objectClassName,
-                let entityId = entity[Entity.Key.entityId],
+                let entityId = entity[Entity.CodingKeys.entityId],
                 let dynamicObject = realm.dynamicObject(ofType: entityType, forPrimaryKey: entityId),
                 let nestedObject = dynamicObject[translatedKey] as? Object,
                 !(nestedObject is Entity)
@@ -778,7 +778,7 @@ extension RealmCache: DynamicCacheType {
             } else if let property = properties[translatedKey],
                 property.isArray,
                 let objectClassName = property.objectClassName,
-                let entityId = entity[Entity.Key.entityId],
+                let entityId = entity[Entity.CodingKeys.entityId],
                 let dynamicObject = realm.dynamicObject(ofType: entityType, forPrimaryKey: entityId),
                 let nestedArray = dynamicObject[translatedKey] as? List<DynamicObject>
             {

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -18,11 +18,25 @@ import ObjectMapper
 open class User: NSObject, Credential, Mappable {
     
     /// Username Key.
+    @available(*, deprecated: 3.17.0, message: "Please use User.CodingKeys.username instead")
     open static let PersistableUsernameKey = "username"
     
+    public enum CodingKeys: String, CodingKey {
+        
+        case username
+        
+    }
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<U, Swift.Error> instead")
     public typealias UserHandler<U: User> = (U?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<[U], Swift.Error> instead")
     public typealias UsersHandler<U: User> = ([U]?, Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<Void, Swift.Error> instead")
     public typealias VoidHandler = (Swift.Error?) -> Void
+    
+    @available(*, deprecated: 3.17.0, message: "Please use Result<Bool, Swift.Error> instead")
     public typealias BoolHandler = (Bool, Swift.Error?) -> Void
     
     /// `_id` property of the user.
@@ -54,6 +68,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Creates a new `User` taking (optionally) a username and password. If no `username` or `password` was provided, random values will be generated automatically.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.signup(username:password:user:options:completionHandler:) instead")
     open class func signup<U: User>(
         username: String? = nil,
         password: String? = nil,
@@ -78,6 +93,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Creates a new `User` taking (optionally) a username and password. If no `username` or `password` was provided, random values will be generated automatically.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.signup(username:password:user:options:completionHandler:) instead")
     open class func signup<U: User>(
         username: String? = nil,
         password: String? = nil,
@@ -217,6 +233,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.login(authSource:_:createIfNotExists:options:completionHandler:) instead")
     open class func login<U: User>(
         authSource: AuthSource,
         _ authData: [String : Any],
@@ -249,6 +266,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.login(authSource:_:createIfNotExists:options:completionHandler:) instead")
     open class func login<U: User>(
         authSource: AuthSource,
         _ authData: [String : Any],
@@ -342,6 +360,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Sign in a user and set as a current active user.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.login(username:password:provider:options:completionHandler:) instead")
     open class func login<U: User>(
         username: String,
         password: String,
@@ -374,6 +393,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.sendEmailConfirmation(forUsername:options:completionHandler:) instead")
     open class func sendEmailConfirmation(
         forUsername username: String,
         client: Client = sharedClient,
@@ -466,6 +486,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Sends an email to the user with a link to reset the password
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.resetPassword(usernameOrEmail:options:completionHandler:) instead")
     private class func resetPassword(
         usernameOrEmail: String,
         client: Client = sharedClient,
@@ -555,6 +576,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.changePassword(newPassword:options:completionHandler:) instead")
     open func changePassword<U: User>(
         newPassword: String,
         completionHandler: UserHandler<U>? = nil
@@ -579,6 +601,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.changePassword(newPassword:options:completionHandler:) instead")
     open func changePassword<U: User>(
         newPassword: String,
         completionHandler: ((Result<U, Swift.Error>) -> Void)? = nil
@@ -616,6 +639,7 @@ open class User: NSObject, Credential, Mappable {
      - parameter completionHandler: Completion handler to be called once the response returns from the server
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.forgotUsername(email:options:completionHandler:) instead")
     open class func forgotUsername(
         email: String,
         client: Client = sharedClient,
@@ -658,6 +682,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Checks if a `username` already exists or not.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.exists(username:options:completionHandler:) instead")
     open class func exists(
         username: String,
         client: Client = sharedClient,
@@ -678,6 +703,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Checks if a `username` already exists or not.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.exists(username:options:completionHandler:) instead")
     open class func exists(
         username: String,
         client: Client = sharedClient,
@@ -727,6 +753,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Gets a `User` instance using the `userId` property.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.get(userId:options:completionHandler:) instead")
     open class func get<U: User>(
         userId: String,
         client: Client = sharedClient,
@@ -747,6 +774,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Gets a `User` instance using the `userId` property.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.get(userId:options:completionHandler:) instead")
     open class func get<U: User>(
         userId: String,
         client: Client = sharedClient,
@@ -879,21 +907,21 @@ open class User: NSObject, Credential, Mappable {
         var acl: Acl?
         var metadata: UserMetadata?
         
-        userId <- map[Entity.Key.entityId]
+        userId <- map[Entity.CodingKeys.entityId]
         guard let userIdValue = userId else {
             return nil
         }
         
-        acl <- map[Entity.Key.acl]
-        metadata <- map[Entity.Key.metadata]
+        acl <- map[Entity.CodingKeys.acl]
+        metadata <- map[Entity.CodingKeys.metadata]
         self.init(userId: userIdValue, acl: acl, metadata: metadata)
     }
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        _userId <- map[Entity.Key.entityId]
-        acl <- map[Entity.Key.acl]
-        metadata <- map[Entity.Key.metadata]
+        _userId <- map[Entity.CodingKeys.entityId]
+        acl <- map[Entity.CodingKeys.acl]
+        metadata <- map[Entity.CodingKeys.metadata]
         socialIdentity <- map["_socialIdentity"]
         username <- map["username"]
         email <- map["email"]
@@ -933,6 +961,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Creates or updates a `User`.
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.save(newPassword:options:completionHandler:) instead")
     open func save<U: User>(
         newPassword: String? = nil,
         completionHandler: UserHandler<U>? = nil
@@ -989,6 +1018,7 @@ open class User: NSObject, Credential, Mappable {
      This method allows users to do exact queries for other users restricted to the `UserQuery` attributes.
      */
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.lookup(_:options:completionHandler:) instead")
     open func lookup<U: User>(
         _ userQuery: UserQuery,
         completionHandler: UsersHandler<U>? = nil

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -159,25 +159,6 @@ open class User: NSObject, Credential, Mappable {
     }
     
     /// Deletes a `User` by the `userId` property.
-    @available(*, deprecated: 3.6.0, message: "Please use destroy(userId:hard:options:completionHandler:) instead")
-    @discardableResult
-    open class func destroy(
-        userId: String,
-        hard: Bool = true,
-        client: Client = Kinvey.sharedClient,
-        completionHandler: ((Result<Void, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<Void, Swift.Error>> {
-        return destroy(
-            userId: userId,
-            hard: hard,
-            options: Options(
-                client: client
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
-    /// Deletes a `User` by the `userId` property.
     @discardableResult
     open class func destroy(
         userId: String,
@@ -383,25 +364,6 @@ open class User: NSObject, Credential, Mappable {
         }
     }
     
-    /// Sign in a user and set as a current active user.
-    @available(*, deprecated: 3.6.0, message: "Please use login(username:password:options:completionHandler:) instead")
-    @discardableResult
-    open class func login<U: User>(
-        username: String,
-        password: String,
-        client: Client = sharedClient,
-        completionHandler: ((Result<U, Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<U, Swift.Error>> {
-        return login(
-            username: username,
-            password: password,
-            options: Options(
-                client: client
-            ),
-            completionHandler: completionHandler
-        )
-    }
-    
     /**
      Sends a request to confirm email address to the specified user.
      
@@ -524,6 +486,7 @@ open class User: NSObject, Credential, Mappable {
     
     /// Sends an email to the user with a link to reset the password
     @discardableResult
+    @available(*, deprecated: 3.17.0, message: "Please use User.resetPassword(usernameOrEmail:options:completionHandler:) instead")
     open class func resetPassword(
         usernameOrEmail: String,
         client: Client = sharedClient,
@@ -557,36 +520,6 @@ open class User: NSObject, Credential, Mappable {
             completionHandler: completionHandler
         )
         return AnyRequest(request)
-    }
-    
-    /// Sends an email to the user with a link to reset the password using the `username` property.
-    @discardableResult
-    @available(*, deprecated: 3.3.4, message: "Use resetPassword(usernameOrEmail:) instead")
-    open class func resetPassword(
-        username: String,
-        client: Client = sharedClient,
-        completionHandler: VoidHandler? = nil
-    ) -> AnyRequest<Result<Void, Swift.Error>> {
-        return resetPassword(
-            usernameOrEmail: username,
-            client: client,
-            completionHandler:  completionHandler
-        )
-    }
-    
-    /// Sends an email to the user with a link to reset the password using the `email` property.
-    @discardableResult
-    @available(*, deprecated: 3.3.4, message: "Use resetPassword(usernameOrEmail:) instead")
-    open class func resetPassword(
-        email: String,
-        client: Client = sharedClient,
-        completionHandler: VoidHandler? = nil
-    ) -> AnyRequest<Result<Void, Swift.Error>> {
-        return resetPassword(
-            usernameOrEmail: email,
-            client: client,
-            completionHandler:  completionHandler
-        )
     }
     
     /// Sends an email to the user with a link to reset the password.
@@ -858,23 +791,6 @@ open class User: NSObject, Credential, Mappable {
             completionHandler?(.failure(error))
         }
         return AnyRequest(request)
-    }
-    
-    /// Gets a `User` instance using the `userId` property.
-    @available(*, deprecated: 3.6.0, message: "Please use find(query:options:completionHandler:) instead")
-    @discardableResult
-    open func find<U: User>(
-        query: Query = Query(),
-        client: Client = sharedClient,
-        completionHandler: ((Result<[U], Swift.Error>) -> Void)? = nil
-    ) -> AnyRequest<Result<[U], Swift.Error>> {
-        return find(
-            query: query,
-            options: Options(
-                client: client
-            ),
-            completionHandler: completionHandler
-        )
     }
     
     /// Gets a `User` instance using the `userId` property.
@@ -1338,24 +1254,6 @@ open class User: NSObject, Credential, Mappable {
     }
     
     /// Performs a login using the MIC Redirect URL that contains a temporary token.
-    @available(*, deprecated: 3.6.0, message: "Please use login(redirectURI:micURL:options:) instead")
-    open class func login(
-        redirectURI: URL,
-        micURL: URL,
-        authServiceId: String? = nil,
-        client: Client = sharedClient
-    ) -> Bool {
-        return login(
-            redirectURI: redirectURI,
-            micURL: micURL,
-            options: Options(
-                client: client,
-                authServiceId: authServiceId
-            )
-        )
-    }
-    
-    /// Performs a login using the MIC Redirect URL that contains a temporary token.
     open class func login(
         redirectURI: URL,
         micURL: URL,
@@ -1390,28 +1288,9 @@ open class User: NSObject, Credential, Mappable {
             return false
         }
     }
-
-    /// Presents the MIC View Controller to sign in a user using MIC (Mobile Identity Connect).
-    @available(*, deprecated: 3.3.2, message: "Please use the method presentMICViewController(micUserInterface:) instead")
-    open class func presentMICViewController(
-        redirectURI: URL,
-        timeout: TimeInterval = 0,
-        forceUIWebView: Bool,
-        authServiceId: String? = nil,
-        client: Client = sharedClient,
-        completionHandler: UserHandler<User>? = nil
-    ) {
-        presentMICViewController(
-            redirectURI: redirectURI,
-            timeout: timeout,
-            micUserInterface: forceUIWebView ? .uiWebView : .wkWebView,
-            authServiceId: authServiceId,
-            client: client,
-            completionHandler: completionHandler
-        )
-    }
     
     /// Presents the MIC View Controller to sign in a user using MIC (Mobile Identity Connect).
+    @available(*, deprecated: 3.17.0, message: "Please use User.presentMICViewController(redirectURI:micUserInterface:currentViewController:options:completionHandler:) instead")
     open class func presentMICViewController<U: User>(
         redirectURI: URL,
         timeout: TimeInterval = 0,
@@ -1439,6 +1318,7 @@ open class User: NSObject, Credential, Mappable {
     }
     
     /// Presents the MIC View Controller to sign in a user using MIC (Mobile Identity Connect).
+    @available(*, deprecated: 3.17.0, message: "Please use User.presentMICViewController(redirectURI:micUserInterface:currentViewController:options:completionHandler:) instead")
     open class func presentMICViewController<U: User>(
         redirectURI: URL,
         timeout: TimeInterval = 0,

--- a/Kinvey/Kinvey/ValidationStrategy.swift
+++ b/Kinvey/Kinvey/ValidationStrategy.swift
@@ -48,7 +48,7 @@ public enum ValidationStrategy: MapContext {
     @inline(__always)
     private func validate(item: Dictionary<String, Any>) -> Swift.Error? {
         guard
-            let id = item[Entity.Key.entityId] as? String,
+            let id = item[Entity.CodingKeys.entityId] as? String,
             !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
             return Error.objectIdMissing

--- a/Kinvey/KinveyApp/LongData.swift
+++ b/Kinvey/KinveyApp/LongData.swift
@@ -54,7 +54,7 @@ class LongData: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        id <- map[PersistableIdKey]
+        id <- map[Entity.CodingKeys.entityId]
         seq <- map["seq"]
         first <- map["first"]
         last <- map["last"]

--- a/Kinvey/KinveyApp/MICAuthorizationGrantViewController.swift
+++ b/Kinvey/KinveyApp/MICAuthorizationGrantViewController.swift
@@ -25,7 +25,16 @@ class MICAuthorizationGrantViewController: UIViewController {
             Kinvey.sharedClient.initialize(
                 appKey: appKey,
                 appSecret: appSecret
-            )
+            ) {
+                switch $0 {
+                case .success(let user):
+                    if let user = user {
+                        print(user)
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
         }
     }
     
@@ -41,11 +50,12 @@ class MICAuthorizationGrantViewController: UIViewController {
                 let store = DataStore<MedData>.collection(.network)
                 
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 5) {
-                    store.find { results, error in
-                        if let results = results {
-                            print("\(results)")
-                        } else if let error = error {
-                            print("\(error)")
+                    store.find {
+                        switch $0 {
+                        case .success(let results):
+                            print(results)
+                        case .failure(let error):
+                            print(error)
                         }
                     }
                 }

--- a/Kinvey/KinveyApp/MICLoginViewController.swift
+++ b/Kinvey/KinveyApp/MICLoginViewController.swift
@@ -65,7 +65,16 @@ open class MICLoginViewController: UIViewController {
                 appSecret: appSecret,
                 apiHostName: apiUrl ?? Client.defaultApiHostName,
                 authHostName: authUrl ?? Client.defaultAuthHostName
-            )
+            ) {
+                switch $0 {
+                case .success(let user):
+                    if let user = user {
+                        print(user)
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
         }
     }
 

--- a/Kinvey/KinveyApp/PerformanceTestLongData.swift
+++ b/Kinvey/KinveyApp/PerformanceTestLongData.swift
@@ -14,9 +14,17 @@ class PerformanceTestLongData: PerformanceTestData {
     override func test() {
         startDate = Date()
         let store: DataStore<LongData> = self.store()
-        store.find(deltaSet: deltaSetSwitch.isOn) { results, error in
+        store.find(options: Options(deltaSet: deltaSetSwitch.isOn)) {
             self.endDate = Date()
-            self.durationLabel.text = "\(self.durationLabel.text ?? "")\n\(results?.count ?? 0)"
+            let count: Int
+            switch $0 {
+            case .success(let results):
+                count = results.count
+            case .failure(let error):
+                print(error)
+                count = 0
+            }
+            self.durationLabel.text = "\(self.durationLabel.text ?? "")\n\(count)"
         }
     }
     

--- a/Kinvey/KinveyApp/UploadAndPlayVideoViewController.swift
+++ b/Kinvey/KinveyApp/UploadAndPlayVideoViewController.swift
@@ -16,7 +16,7 @@ class UploadAndPlayVideoViewController: UIViewController, UIImagePickerControlle
 
     @IBOutlet weak var progressView: UIProgressView!
     
-    lazy var fileStore = FileStore.getInstance()
+    lazy var fileStore = FileStore()
     var file: File?
     
     override func viewDidLoad() {

--- a/Kinvey/KinveyMacAppTests/PerformanceTest.swift
+++ b/Kinvey/KinveyMacAppTests/PerformanceTest.swift
@@ -126,7 +126,7 @@ class PerformanceTest: XCTestCase {
             print("Time elapsed to count \(sapCustomerNumber): \(CFAbsoluteTimeGetCurrent() - startTime) s.")
         }
         
-        Kinvey.sharedClient.timeoutInterval = 600
+        Kinvey.sharedClient.options = Options(timeout: 600)
         let limit = 10000
         
         measure {
@@ -279,7 +279,7 @@ class PerformanceTest: XCTestCase {
             print("Time elapsed to count \(sapCustomerNumber): \(CFAbsoluteTimeGetCurrent() - startTime) s.")
         }
         
-        Kinvey.sharedClient.timeoutInterval = 600
+        Kinvey.sharedClient.options = Options(timeout: 600)
         
         measure {
             let startTime = CFAbsoluteTimeGetCurrent()

--- a/Kinvey/KinveyTests/AclTestCase.swift
+++ b/Kinvey/KinveyTests/AclTestCase.swift
@@ -37,31 +37,34 @@ class AclTestCase: StoreTestCase {
         
         weak var expectationRemove = expectation(description: "Remove")
         
-        try! store.remove(person) { (count, error) -> Void in
+        try! store.remove(person) {
             self.assertThread()
-            XCTAssertNil(count)
-            XCTAssertNotNil(error)
-            XCTAssertNotNil(error as? Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                let result = error.responseBodyJsonDictionary
-                XCTAssertNotNil(result)
-                if let result = result {
-                    let expected = [
-                        "description" : "The credentials used to authenticate this request are not authorized to run this operation. Please retry your request with appropriate credentials",
-                        "debug" : "",
-                        "error" : "InsufficientCredentials"
-                    ]
-                    XCTAssertEqual(result.count, expected.count)
-                    XCTAssertEqual(result["description"] as? String, expected["description"])
-                    XCTAssertEqual(result["debug"] as? String, expected["debug"])
-                    XCTAssertEqual(result["error"] as? String, expected["error"])
-                }
-                switch error {
-                case .unauthorized(_, _, let error, _, _):
-                    XCTAssertEqual(error, Kinvey.Error.Keys.insufficientCredentials.rawValue)
-                default:
-                    XCTFail()
+            switch $0 {
+            case .success(let count):
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                XCTAssertNotNil(error as? Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    let result = error.responseBodyJsonDictionary
+                    XCTAssertNotNil(result)
+                    if let result = result {
+                        let expected = [
+                            "description" : "The credentials used to authenticate this request are not authorized to run this operation. Please retry your request with appropriate credentials",
+                            "debug" : "",
+                            "error" : "InsufficientCredentials"
+                        ]
+                        XCTAssertEqual(result.count, expected.count)
+                        XCTAssertEqual(result["description"] as? String, expected["description"])
+                        XCTAssertEqual(result["debug"] as? String, expected["debug"])
+                        XCTAssertEqual(result["error"] as? String, expected["error"])
+                    }
+                    switch error {
+                    case .unauthorized(_, _, let error, _, _):
+                        XCTAssertEqual(error, Kinvey.Error.Keys.insufficientCredentials.rawValue)
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -107,10 +110,14 @@ class AclTestCase: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(person.personId!, readPolicy: .forceNetwork) { person, error in
+            store.find(person.personId!, options: Options(readPolicy: .forceNetwork)) {
                 self.assertThread()
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let person):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -125,10 +132,14 @@ class AclTestCase: StoreTestCase {
         do {
             weak var expectationRemove = expectation(description: "Remove")
             
-            try! store.remove(person) { (count, error) -> Void in
+            try! store.remove(person) {
                 self.assertThread()
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let count):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationRemove?.fulfill()
             }
@@ -220,11 +231,9 @@ class AclTestCase: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(personId) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.find(personId) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.acl)
                     if let acl = person.acl {
                         XCTAssertNotNil(acl.globalRead)
@@ -232,6 +241,8 @@ class AclTestCase: StoreTestCase {
                             XCTAssertTrue(globalRead)
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -277,11 +288,9 @@ class AclTestCase: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(personId) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.find(personId) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.acl)
                     if let acl = person.acl {
                         XCTAssertNotNil(acl.globalWrite)
@@ -289,6 +298,8 @@ class AclTestCase: StoreTestCase {
                             XCTAssertTrue(globalWrite)
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -342,11 +353,9 @@ class AclTestCase: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(personId) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.find(personId) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.acl)
                     if let acl = person.acl {
                         XCTAssertNotNil(acl.readers)
@@ -355,6 +364,8 @@ class AclTestCase: StoreTestCase {
                             XCTAssertEqual(readers.first, user.userId)
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -405,11 +416,9 @@ class AclTestCase: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(personId) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.find(personId) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.acl)
                     if let acl = person.acl {
                         XCTAssertNotNil(acl.writers)
@@ -417,6 +426,8 @@ class AclTestCase: StoreTestCase {
                             XCTAssertEqual(writers.count, 1)
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()

--- a/Kinvey/KinveyTests/CacheMigrationTestCaseStep1.swift
+++ b/Kinvey/KinveyTests/CacheMigrationTestCaseStep1.swift
@@ -60,7 +60,14 @@ class CacheMigrationTestCaseStep1: XCTestCase {
     }
     
     func testMigration() {
-        Kinvey.sharedClient.initialize(appKey: "appKey", appSecret: "appSecret")
+        Kinvey.sharedClient.initialize(appKey: "appKey", appSecret: "appSecret") {
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
         
         let store = DataStore<Person>.collection(.sync)
         
@@ -70,13 +77,13 @@ class CacheMigrationTestCaseStep1: XCTestCase {
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
-            
-            if let person = person {
+        store.save(person) {
+            switch $0 {
+            case .success(let person):
                 XCTAssertEqual(person.firstName, "Victor")
                 XCTAssertEqual(person.lastName, "Barros")
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationSave?.fulfill()

--- a/Kinvey/KinveyTests/ClientTestCase.swift
+++ b/Kinvey/KinveyTests/ClientTestCase.swift
@@ -181,7 +181,7 @@ class ClientTestCase: KinveyTestCase {
     func testDataStoreWithoutInitilizeClient() {
         expect { () -> Void in
             let client = Client()
-            let _ = DataStore<Person>.collection(client: client)
+            let _ = DataStore<Person>.collection(options: Options(client: client))
         }.to(throwAssertion())
     }
     

--- a/Kinvey/KinveyTests/CustomEndpointTests.swift
+++ b/Kinvey/KinveyTests/CustomEndpointTests.swift
@@ -104,7 +104,7 @@ class CustomEndpointTests: KinveyTestCase {
         
         weak var expectationCustomEndpoint = expectation(description: "Custom Endpoint")
         
-        let params: JsonDictionary? = nil
+        let params: CustomEndpoint.Params? = nil
         CustomEndpoint.execute("echo", params: params) { (response: JsonDictionary?, error) in
             XCTAssertNotNil(response)
             XCTAssertNil(error)
@@ -135,7 +135,7 @@ class CustomEndpointTests: KinveyTestCase {
         
         weak var expectationCustomEndpoint = expectation(description: "Custom Endpoint")
         
-        let params: JsonDictionary? = nil
+        let params: CustomEndpoint.Params? = nil
         CustomEndpoint.execute("echo", params: params) { (response: [JsonDictionary]?, error) in
             XCTAssertNil(response)
             XCTAssertNotNil(error)
@@ -230,12 +230,12 @@ class CustomEndpointTests: KinveyTestCase {
     func testCustomEndpointJsonArray() {
         signUp()
         
-        let params: [String : Any] = [
+        let params = CustomEndpoint.Params([
             "stringParam" : "Test",
             "numberParam" : 1,
             "booleanParam" : true,
             "queryParam" : Query(format: "age >= %@", 21)
-        ]
+        ])
         
         if useMockData {
             mockResponse(json: [
@@ -564,9 +564,9 @@ class CustomEndpointTests: KinveyTestCase {
     func testQueryCount() {
         signUp()
         
-        let params = [
+        let params = CustomEndpoint.Params([
             "query" : Query(format: "colors.@count == %@", 2)
-        ]
+        ])
         
         if useMockData {
             mockResponse(json: [
@@ -872,7 +872,7 @@ class CustomEndpointTests: KinveyTestCase {
     func test404Error() {
         signUp()
         
-        let params = [String : Any]()
+        let params = CustomEndpoint.Params([:])
         
         if useMockData {
             mockResponse(statusCode: 404, json: [:])
@@ -900,7 +900,7 @@ class CustomEndpointTests: KinveyTestCase {
     func test404ErrorNoCompletionBlock() {
         signUp()
         
-        let params = [String : Any]()
+        let params = CustomEndpoint.Params([:])
         
         if useMockData {
             mockResponse(statusCode: 404, json: [:])
@@ -937,7 +937,7 @@ class CustomEndpointTests: KinveyTestCase {
         
         weak var expectationCustomEndpoint = expectation(description: "Custom Endpoint")
         
-        let params: JsonDictionary? = nil
+        let params: CustomEndpoint.Params? = nil
         let completionHandler: ((JsonDictionary?, Swift.Error?) -> Void)? = nil
         let request = CustomEndpoint.execute("echo", params: params, completionHandler: completionHandler)
         XCTAssertTrue(wait(toBeTrue: !request.executing))
@@ -1199,11 +1199,11 @@ class CustomEndpointTests: KinveyTestCase {
     func testNestedDictionary() {
         signUp()
         
-        let params = [
+        let params = CustomEndpoint.Params([
             "query" : [
                 "query" : Query(format: "colors.@count == %@", 2)
             ]
-        ]
+        ])
         
         if useMockData {
             mockResponse(json: [
@@ -1257,12 +1257,12 @@ class CustomEndpointTests: KinveyTestCase {
     func testNestedArray() {
         signUp()
         
-        let params = [
+        let params = CustomEndpoint.Params([
             "queries" : [
                 Query(format: "colors.@count == %@", 2),
                 Query(format: "colors.@count == %@", 5)
             ]
-        ]
+        ])
         
         if useMockData {
             mockResponse(json: [

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -91,11 +91,9 @@ class DataTypeTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(query) { results, error in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(query) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
                 
                 if let dataType = results.first {
@@ -115,6 +113,8 @@ class DataTypeTestCase: StoreTestCase {
                         XCTAssertEqual(fullName.fontDescriptor, FontDescriptor(name: "Arial", size: 12))
                     }
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -165,16 +165,16 @@ class DataTypeTestCase: StoreTestCase {
         
         let query = Query(format: "acl.creator == %@", client.activeUser!.userId)
         
-        store.find(query) { results, error in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(query) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertGreaterThan(results.count, 0)
                 
                 if let dataType = results.first {
                     XCTAssertNotNil(dataType.date)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()

--- a/Kinvey/KinveyTests/DateTestCase.swift
+++ b/Kinvey/KinveyTests/DateTestCase.swift
@@ -96,9 +96,13 @@ class DateTestCase: KinveyTestCase {
             
             let event = Event()
             event.publishDate = publishDate
-            store.save(event) { event, error in
-                XCTAssertNotNil(event)
-                XCTAssertNil(error)
+            store.save(event) {
+                switch $0 {
+                case .success(let event):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationSave?.fulfill()
             }
@@ -121,18 +125,18 @@ class DateTestCase: KinveyTestCase {
             weak var expectationFind = self.expectation(description: "Find")
             
             let query = Query(format: "acl.creator == %@ AND publishDate >= %@", Kinvey.sharedClient.activeUser!.userId, Date(timeIntervalSinceNow: -60))
-            store.find(query) { events, error in
-                XCTAssertNotNil(events)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(events?.count, nEvents)
-                if let events = events {
+            store.find(query) {
+                switch $0 {
+                case .success(let events):
+                    XCTAssertEqual(events.count, nEvents)
                     for event in events {
                         XCTAssertNotNil(event.publishDate)
                         if let date = event.publishDate {
                             XCTAssertEqual(date.timeIntervalSinceReferenceDate, publishDate.timeIntervalSinceReferenceDate, accuracy: 0.0009)
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -17,7 +17,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     override func tearDown() {
         if let activeUser = client.activeUser {
             let store = DataStore<Person>.collection(.network)
-            let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+            let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
             
             if useMockData {
                 mockResponse(json: ["count" : mockCount])
@@ -31,9 +31,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationRemoveAll = expectation(description: "Remove All")
             
-            store.remove(query) { (count, error) -> Void in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
+            store.remove(query) {
+                switch $0 {
+                case .success(let count):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationRemoveAll?.fulfill()
             }
@@ -52,19 +56,19 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         do {
             let person = Person()
             person.personId = "update"
-            person.metadata = Metadata(JSON: [Metadata.LmtKey : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
             cache.save(entity: person)
         }
         do {
             let person = Person()
             person.personId = "noChange"
-            person.metadata = Metadata(JSON: [Metadata.LmtKey : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
             cache.save(entity: person)
         }
         do {
             let person = Person()
             person.personId = "delete"
-            person.metadata = Metadata(JSON: [Metadata.LmtKey : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
             cache.save(entity: person)
         }
         let operation = Operation(
@@ -76,21 +80,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         let query = Query()
         let refObjs: [JsonDictionary] = [
             [
-                PersistableIdKey : "create",
-                PersistableMetadataKey : [
-                    Metadata.LmtKey : date.toString(),
+                Entity.CodingKeys.entityId.rawValue : "create",
+                Entity.CodingKeys.metadata.rawValue : [
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString(),
                 ]
             ],
             [
-                PersistableIdKey : "update",
-                PersistableMetadataKey : [
-                    Metadata.LmtKey : Date(timeInterval: 1, since: date).toString()
+                Entity.CodingKeys.entityId.rawValue : "update",
+                Entity.CodingKeys.metadata.rawValue : [
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date(timeInterval: 1, since: date).toString()
                 ]
             ],
             [
-                PersistableIdKey : "noChange",
-                PersistableMetadataKey : [
-                    Metadata.LmtKey : date.toString()
+                Entity.CodingKeys.entityId.rawValue : "noChange",
+                Entity.CodingKeys.metadata.rawValue : [
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()
                 ]
             ]
         ]
@@ -145,9 +149,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationSaveLocal = expectation(description: "Save Local")
             weak var expectationSaveRemote = expectation(description: "Save Remote")
             
-            store.save(person) { (person, error) -> Void in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+            store.save(person) {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 if let expectation = expectationSaveLocal {
                     expectation.fulfill()
@@ -214,21 +222,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
         query.ascending("name")
         
         do {
             weak var expectationRead = expectation(description: "Read")
             
-            store.find(query, readPolicy: .forceLocal) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 1)
                     if let person = persons.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationRead?.fulfill()
@@ -277,11 +285,9 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 2)
                     if let person = persons.first {
                         XCTAssertEqual(person.name, "Victor")
@@ -289,6 +295,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     if let person = persons.last {
                         XCTAssertEqual(person.name, "Victor Barros")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -337,9 +345,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationSaveLocal = expectation(description: "Save Local")
             weak var expectationSaveRemote = expectation(description: "Save Remote")
             
-            store.save(person) { (person, error) -> Void in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+            store.save(person) {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 if let expectation = expectationSaveLocal {
                     expectation.fulfill()
@@ -410,21 +422,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
         query.ascending("name")
         
         do {
             weak var expectationRead = expectation(description: "Read")
             
-            store.find(query, readPolicy: .forceLocal) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 1)
                     if let person = persons.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationRead?.fulfill()
@@ -460,15 +472,15 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 1)
                     if let person = persons.first {
                         XCTAssertEqual(person.name, "Victor Barros")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -517,9 +529,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationSaveLocal = expectation(description: "Save Local")
             weak var expectationSaveRemote = expectation(description: "Save Remote")
             
-            store.save(person) { (person, error) -> Void in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+            store.save(person) {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 if let expectation = expectationSaveLocal {
                     expectation.fulfill()
@@ -577,21 +593,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
         query.ascending("name")
         
         do {
             weak var expectationRead = expectation(description: "Read")
             
-            store.find(query, readPolicy: .forceLocal) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 1)
                     if let person = persons.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationRead?.fulfill()
@@ -614,12 +630,12 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 0)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -715,9 +731,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationSave = self.expectation(description: "Save")
             
-            store.save(person, writePolicy: .forceNetwork) { (person, error) -> Void in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+            store.save(person, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationSave?.fulfill()
             }
@@ -737,22 +757,22 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         let store = DataStore<Person>.collection(.sync)
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
         query.ascending("name")
         
         do {
             weak var expectationRead = expectation(description: "Read")
             
-            store.find(query, readPolicy: .forceLocal) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 5)
                     
                     for (i, person) in persons.enumerated() {
                         XCTAssertEqual(person.name, String(format: "Person Cached %02d", i + 1))
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationRead?.fulfill()
@@ -1024,9 +1044,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 
                 weak var expectationSave = self.expectation(description: "Save")
                 
-                store.save(person) { (person, error) -> Void in
-                    XCTAssertNotNil(person)
-                    XCTAssertNil(error)
+                store.save(person) {
+                    switch $0 {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationSave?.fulfill()
                 }
@@ -1042,22 +1066,22 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         let store = DataStore<Person>.collection(.sync)
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", activeUser.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", activeUser.userId)
         query.ascending("name")
         
         do {
             weak var expectationRead = self.expectation(description: "Read")
             
-            store.find(query, readPolicy: .forceLocal) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, countLocal)
                     
                     for (i, person) in persons.enumerated() {
                         XCTAssertEqual(person.name, String(format: "Person Cached %03d", i + 1))
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationRead?.fulfill()
@@ -1073,22 +1097,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         do {
             weak var expectationFind = self.expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { (persons, error) -> Void in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, countBackend + countLocal)
                     if persons.count > 0 {
-                        for (i, person) in persons[0..<countBackend].enumerated() {
+                        for (i, person) in persons[AnyIndex(0) ..< AnyIndex(countBackend)].enumerated() {
                             XCTAssertEqual(person.name, String(format: "Person %03d", i + 1))
                         }
-                        for (i, person) in persons[countBackend..<persons.count].enumerated() {
+                        for (i, person) in persons[AnyIndex(countBackend) ..< AnyIndex(persons.count)].enumerated() {
                             XCTAssertEqual(person.name, String(format: "Person Cached %03d", i + 1))
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
-                
                 expectationFind?.fulfill()
             }
             
@@ -1124,7 +1147,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         signUp()
         
         let store = DataStore<Person>.collection()
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         if useMockData {
             mockResponse(json: [])
@@ -1137,12 +1160,12 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(query, readPolicy: .forceNetwork) { results, error in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(query, options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 0)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -1164,12 +1187,12 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         do {
             weak var expectationSave = expectation(description: "Save")
             
-            store.save(person) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.save(person) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertEqual(person.name, "Victor")
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationSave?.fulfill()
@@ -1239,7 +1262,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 }
             }
             
-            let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+            let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
             
             weak var expectationPull = expectation(description: "Pull")
             
@@ -1264,7 +1287,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         signUp()
         
         let store = DataStore<Person>.collection()
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         class OnePersonURLProtocol: URLProtocol {
             
@@ -1315,16 +1338,16 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(query, readPolicy: .forceNetwork) { results, error in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(query, options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
                 
                 if let person = results.first {
                     XCTAssertEqual(person.name, "Person 1")
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -1338,17 +1361,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     func testFindOneRecordDeltaSetNoChange() {
         signUp()
         
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         let person = Person()
         person.name = "Victor"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
+        store.save(person) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -1397,7 +1424,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         do {
             var mockCount = 0
@@ -1432,16 +1459,16 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                if let results = results {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
                     XCTAssertEqual(results.count, 1)
                     
                     if let person = results.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -1500,17 +1527,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     func testFindOneRecordDeltaSetChanged() {
         signUp()
         
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         let person = Person()
         person.name = "Victor"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
+        store.save(person) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -1559,7 +1590,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         do {
             var mockCount = 0
@@ -1595,16 +1626,16 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                if let results = results {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
                     XCTAssertEqual(results.count, 1)
                     
                     if let person = results.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -1708,17 +1739,17 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(queryFields, readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                if let results = results {
+            store.find(queryFields, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
                     XCTAssertEqual(results.count, 1)
                     
                     if let person = results.first {
                         XCTAssertNil(person.name)
                         XCTAssertEqual(person.age, 1)
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -1789,17 +1820,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     func testFindOneRecordDeltaSetNoKmd() {
         signUp()
         
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         let person = Person()
         person.name = "Victor"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
+        store.save(person) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -1847,7 +1882,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         do {
             if useMockData {
@@ -1873,16 +1908,16 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                if let results = results {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
                     XCTAssertEqual(results.count, 1)
                     
                     if let person = results.first {
                         XCTAssertEqual(person.name, "Victor")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -1952,7 +1987,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     }
     
     func testFindOneRecordDeltaSetTimeoutError2ndRequest() {
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         do {
             let person = Person()
@@ -1960,10 +1995,14 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationSave = expectation(description: "Save")
             
-            store.save(person) { (person, error) in
+            store.save(person) {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationSave?.fulfill()
             }
@@ -1980,11 +2019,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { (persons, error) in
-            XCTAssertNil(persons)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationFind?.fulfill()
         }
@@ -1997,17 +2038,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     func testFind201RecordsDeltaSet() {
         signUp()
         
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         let person = Person()
         person.name = "Victor"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
+        store.save(person) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -2048,7 +2093,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         var jsonArray = [JsonDictionary]()
         for _ in 1...201 {
@@ -2074,11 +2119,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(results?.count, 201)
+            store.find(options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
+                    XCTAssertEqual(results.count, 201)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -2106,11 +2153,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(results?.count, 201)
+            store.find(options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
+                    XCTAssertEqual(results.count, 201)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -2124,17 +2173,21 @@ class DeltaSetCacheTestCase: KinveyTestCase {
     func testFind201RecordsDeltaSetTimeoutOn2ndRequest() {
         signUp()
         
-        let store = DataStore<Person>.collection(.sync, deltaSet: true)
+        let store = DataStore<Person>.collection(.sync, options: Options(deltaSet: true))
         
         let person = Person()
         person.name = "Victor"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { (person, error) in
+        store.save(person) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -2175,7 +2228,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             }
         }
         
-        let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator == %@", client.activeUser!.userId)
+        let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator == %@", client.activeUser!.userId)
         
         var jsonArray = [JsonDictionary]()
         for _ in 1...201 {
@@ -2199,9 +2252,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { results, error in
-            XCTAssertNil(results)
-            XCTAssertNotNil(error)
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                break
+            }
             
             expectationFind?.fulfill()
         }

--- a/Kinvey/KinveyTests/DirectoryEntry.swift
+++ b/Kinvey/KinveyTests/DirectoryEntry.swift
@@ -34,7 +34,7 @@ class DirectoryEntry: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        uniqueId <- map[PersistableIdKey]
+        uniqueId <- map[Entity.CodingKeys.entityId]
         nameFirst <- map["nameFirst"]
         nameLast <- map["nameLast"]
         email <- map["email"]

--- a/Kinvey/KinveyTests/EncryptedDataStoreTestCase.swift
+++ b/Kinvey/KinveyTests/EncryptedDataStoreTestCase.swift
@@ -30,7 +30,7 @@ class EncryptedDataStoreTestCase: StoreTestCase {
     func testEncryptedDataStore() {
         signUp()
         
-        store = DataStore<Person>.collection(.network, client: client)
+        store = DataStore<Person>.collection(.network, options: Options(client: client))
         
         save(newPerson)
     }

--- a/Kinvey/KinveyTests/FileTestCase.swift
+++ b/Kinvey/KinveyTests/FileTestCase.swift
@@ -49,7 +49,7 @@ class FileTestCase: StoreTestCase {
     }
     
     lazy var fileStore: FileStore = {
-        return FileStore.getInstance()
+        return FileStore()
     }()
     
     override func setUp() {
@@ -639,7 +639,7 @@ class FileTestCase: StoreTestCase {
         self.file = file
         let path = caminandes3TrailerURL.path
         
-        let fileStore = FileStore.getInstance(fileType: MyFile.self)
+        let fileStore = FileStore<MyFile>()
         
         var uploadProgressCount = 0
         
@@ -1620,7 +1620,7 @@ class FileTestCase: StoreTestCase {
         self.file = file
         let path = caminandes3TrailerURL.path
         
-        let fileStore: FileStore<MyFile> = FileStore.getInstance()
+        let fileStore = FileStore<MyFile>()
         
         do {
             if useMockData {
@@ -2440,7 +2440,7 @@ class FileTestCase: StoreTestCase {
     func testGetInstance() {
         let appKey = "file-get_instance-\(UUID().uuidString)"
         let client = Client(appKey: appKey, appSecret: "unit-test")
-        let fileStore = FileStore.getInstance(client: client)
+        let fileStore = FileStore(client: client)
         
         let fileCache = fileStore.cache?.cache as? RealmFileCache<File>
         XCTAssertNotNil(fileCache)
@@ -2582,7 +2582,7 @@ class FileTestCase: StoreTestCase {
                             $0.writers = [userId]
                         }
                     }
-                    let fileStore = FileStore.getInstance()
+                    let fileStore = FileStore()
                     
                     weak var expectationUpload = expectation(description: "Upload")
                     
@@ -2677,7 +2677,7 @@ class FileTestCase: StoreTestCase {
                 XCTAssertNotNil(Kinvey.sharedClient.activeUser)
                 
                 let file = File { $0.fileId = uploadedFileId }
-                let fileStore = FileStore.getInstance()
+                let fileStore = FileStore()
                 
                 do {
                     if useMockData {
@@ -2799,7 +2799,7 @@ class FileTestCase: StoreTestCase {
     func testFind() {
         signUp()
         
-        let fileStore = FileStore.getInstance()
+        let fileStore = FileStore()
         
         if useMockData {
             mockResponse(json: [
@@ -2849,7 +2849,7 @@ class FileTestCase: StoreTestCase {
     func testRefresh() {
         signUp()
         
-        let fileStore = FileStore.getInstance()
+        let fileStore = FileStore()
         var _file: File? = nil
         
         do {
@@ -2964,7 +2964,7 @@ class FileTestCase: StoreTestCase {
     func testRefreshTimeoutError() {
         signUp()
         
-        let fileStore = FileStore.getInstance()
+        let fileStore = FileStore()
         var _file: File? = nil
         
         do {

--- a/Kinvey/KinveyTests/FindOperationTest.swift
+++ b/Kinvey/KinveyTests/FindOperationTest.swift
@@ -27,13 +27,13 @@ class FindOperationTest: StoreTestCase {
         
         weak var expectationSave = expectation(description: "Save")
 
-        store.save(person, writePolicy: .forceLocal) { (person, error) -> Void in
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
-            
-            if let person = person {
+        store.save(person, options: Options(writePolicy: .forceLocal)) {
+            switch $0 {
+            case .success(let person):
                 XCTAssertEqual(person, self.person)
                 XCTAssertNotNil(person.personId)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationSave?.fulfill()
@@ -54,9 +54,13 @@ class FindOperationTest: StoreTestCase {
             weak var expectationGet = expectation(description: "Get")
             
             let query = Query(format: "personId == %@", personId)
-            store.find(query, readPolicy: .forceLocal) { (person, error) -> Void in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let person):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationGet?.fulfill()
             }
@@ -79,12 +83,12 @@ class FindOperationTest: StoreTestCase {
             weak var expectationGet = expectation(description: "Get")
             
             let query = Query(format: "personId == %@", personId)
-            store.find(query, readPolicy: .forceLocal) { (persons, error) -> Void in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertEqual(persons.count, 0)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationGet?.fulfill()

--- a/Kinvey/KinveyTests/ForgotToCallSuper.swift
+++ b/Kinvey/KinveyTests/ForgotToCallSuper.swift
@@ -38,7 +38,7 @@ class ForgotToCallSuperEntity2: Entity {
     }
     
     override func propertyMapping(_ map: Map) {
-        myId <- ("myId", map[Key.entityId])
+        myId <- ("myId", map[CodingKeys.entityId])
         myProperty <- ("myProperty", map["myProperty"])
     }
     

--- a/Kinvey/KinveyTests/JsonTestCase.swift
+++ b/Kinvey/KinveyTests/JsonTestCase.swift
@@ -14,7 +14,7 @@ class JsonTestCase: StoreTestCase {
     func testFromToJson() {
         signUp()
         
-        let storeProject = DataStore<RefProject>.collection(.network, client: client)
+        let storeProject = DataStore<RefProject>.collection(.network, options: Options(client: client))
         
         let project = RefProject()
         project.name = "Mall"
@@ -41,14 +41,14 @@ class JsonTestCase: StoreTestCase {
             
             weak var expectationCreateMall = expectation(description: "CreateMall")
             
-            storeProject.save(project) { (project, error) -> Void in
+            storeProject.save(project) {
                 self.assertThread()
-                XCTAssertNotNil(project)
-                XCTAssertNil(error)
-                
-                if let project = project {
+                switch $0 {
+                case .success(let project):
                     XCTAssertNotNil(project.uniqueId)
                     XCTAssertNotEqual(project.uniqueId, "")
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationCreateMall?.fulfill()
@@ -62,7 +62,7 @@ class JsonTestCase: StoreTestCase {
         XCTAssertNotNil(project.uniqueId)
         XCTAssertNotEqual(project.uniqueId, "")
         
-        let storeDirectory = DataStore<DirectoryEntry>.collection(.network, client: client)
+        let storeDirectory = DataStore<DirectoryEntry>.collection(.network, options: Options(client: client))
         
         let directory = DirectoryEntry()
         directory.nameFirst = "Victor"
@@ -94,14 +94,14 @@ class JsonTestCase: StoreTestCase {
             
             weak var expectationCreateDirectory = expectation(description: "CreateDirectory")
             
-            storeDirectory.save(directory) { (directory, error) -> Void in
+            storeDirectory.save(directory) {
                 self.assertThread()
-                XCTAssertNotNil(directory)
-                XCTAssertNil(error)
-                
-                if let directory = directory {
+                switch $0 {
+                case .success(let directory):
                     XCTAssertNotNil(directory.uniqueId)
                     XCTAssertNotEqual(directory.uniqueId, "")
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationCreateDirectory?.fulfill()

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -309,7 +309,16 @@ class KinveyTestCase: XCTestCase {
                 appSecret: KinveyTestCase.appInitializeDevelopment.appSecret,
                 apiHostName: URL(string: "https://v3yk1n-kcs.kinvey.com")!,
                 encrypted: encrypted
-            )
+            ) {
+                switch $0 {
+                case .success(let user):
+                    if let user = user {
+                        print(user)
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
         }
     }
     
@@ -320,7 +329,16 @@ class KinveyTestCase: XCTestCase {
                 appSecret: KinveyTestCase.appSecret ?? KinveyTestCase.appInitializeProduction.appSecret,
                 apiHostName: KinveyTestCase.hostUrl ?? Client.defaultApiHostName,
                 encrypted: encrypted
-            )
+            ) {
+                switch $0 {
+                case .success(let user):
+                    if let user = user {
+                        print(user)
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
         }
         
     }
@@ -543,13 +561,13 @@ class KinveyTestCase: XCTestCase {
     func decorateJsonFromPostRequest(_ request: URLRequest) -> JsonDictionary {
         XCTAssertEqual(request.httpMethod, "POST")
         var json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
-        json[PersistableIdKey] = UUID().uuidString
-        json[PersistableAclKey] = [
+        json[Entity.CodingKeys.entityId] = UUID().uuidString
+        json[Entity.CodingKeys.acl] = [
             Acl.Key.creator : self.client.activeUser!.userId
         ]
-        json[PersistableMetadataKey] = [
-            Metadata.LmtKey : Date().toString(),
-            Metadata.EctKey : Date().toString()
+        json[Entity.CodingKeys.metadata] = [
+            Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
+            Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
         ]
         return json
     }

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -50,15 +50,15 @@ class NetworkStoreTests: StoreTestCase {
         do {
             weak var expectationCreate = expectation(description: "Create")
             
-            let request = store.save(event) { event, error in
-                XCTAssertNotNil(event)
-                XCTAssertNil(error)
-                
-                if let event = event {
+            let request = store.save(event) {
+                switch $0 {
+                case .success(let event):
                     XCTAssertNotNil(event.entityId)
                     XCTAssertNotNil(event.name)
                     XCTAssertNotNil(event.publishDate)
                     XCTAssertNotNil(event.location)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationCreate?.fulfill()
@@ -86,15 +86,15 @@ class NetworkStoreTests: StoreTestCase {
         if let eventId = event.entityId {
             weak var expectationFind = expectation(description: "Find")
             
-            let request = store.find(eventId) { event, error in
-                XCTAssertNotNil(event)
-                XCTAssertNil(error)
-                
-                if let event = event {
+            let request = store.find(eventId) {
+                switch $0 {
+                case .success(let event):
                     XCTAssertNotNil(event.entityId)
                     XCTAssertNotNil(event.name)
                     XCTAssertNotNil(event.publishDate)
                     XCTAssertNotNil(event.location)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -158,10 +158,14 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            let request = store.find() { (events, error) in
+            let request = store.find() {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(events)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let events):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -219,16 +223,16 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person, writePolicy: .forceNetwork) { person, error in
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
-            
-            if let person = person {
+        store.save(person, options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let person):
                 XCTAssertNotNil(person.address)
                 
                 if let address = person.address {
                     XCTAssertNotNil(address.city)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationSave?.fulfill()
@@ -350,13 +354,14 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationCount = expectation(description: "Count")
             
-            store.count { (count, error) in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(count, 85)
-                
-                eventsCount = count
+            store.count {
+                switch $0 {
+                case .success(let count):
+                    XCTAssertEqual(count, 85)
+                    eventsCount = count
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationCount?.fulfill()
             }
@@ -369,11 +374,13 @@ class NetworkStoreTests: StoreTestCase {
         do {
             weak var expectationCount = expectation(description: "Count")
             
-            store.count(readPolicy: .forceLocal) { (count, error) in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(count, 0)
+            store.count(options: Options(readPolicy: .forceLocal)) {
+                switch $0 {
+                case .success(let count):
+                    XCTAssertEqual(count, 0)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationCount?.fulfill()
             }
@@ -410,9 +417,13 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationCreate = expectation(description: "Create")
             
-            store.save(event) { event, error in
-                XCTAssertNotNil(event)
-                XCTAssertNil(error)
+            store.save(event) {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationCreate?.fulfill()
             }
@@ -434,12 +445,15 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationCount = expectation(description: "Count")
             
-            store.count { (count, error) in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
-                
-                if let eventsCount = eventsCount, let count = count {
-                    XCTAssertEqual(eventsCount + 1, count)
+            store.count {
+                switch $0 {
+                case .success(let count):
+                    XCTAssertNotNil(eventsCount)
+                    if let eventsCount = eventsCount {
+                        XCTAssertEqual(eventsCount + 1, count)
+                    }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationCount?.fulfill()
@@ -669,11 +683,13 @@ class NetworkStoreTests: StoreTestCase {
         
         let query = Query(format: "publishDate >= %@", Date())
         
-        store.count(query) { (count, error) in
-            XCTAssertNotNil(count)
-            XCTAssertNil(error)
-            
-            XCTAssertEqual(count, 85)
+        store.count(query) {
+            switch $0 {
+            case .success(let count):
+                XCTAssertEqual(count, 85)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationCount?.fulfill()
         }
@@ -693,11 +709,13 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationCount = expectation(description: "Count")
         
-        store.count { (count, error) in
-            XCTAssertNil(count)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        store.count {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationCount?.fulfill()
         }
@@ -746,9 +764,13 @@ class NetworkStoreTests: StoreTestCase {
                 
                 weak var expectationSave = self.expectation(description: "Save")
                 
-                self.store.save(person, writePolicy: .forceNetwork) { person, error in
-                    XCTAssertNotNil(person)
-                    XCTAssertNil(error)
+                self.store.save(person, options: Options(writePolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationSave?.fulfill()
                 }
@@ -804,11 +826,9 @@ class NetworkStoreTests: StoreTestCase {
                 $0.ascending("name")
             }
             
-            store.find(query, readPolicy: .forceNetwork) { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
-                
-                if let results = results {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let results):
                     XCTAssertEqual(results.count, limit)
                     
                     XCTAssertNotNil(results.first)
@@ -822,6 +842,8 @@ class NetworkStoreTests: StoreTestCase {
                     if let person = results.last {
                         XCTAssertEqual(person.name, "Person \(skip + 1)")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 skip += limit
@@ -906,18 +928,20 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find("sample-id", readPolicy: .forceNetwork) { person, error in
-            XCTAssertNil(person)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .dataLinkEntityNotFound(_, _, let debug, let description):
-                    XCTAssertEqual(debug, "Error: Not Found")
-                    XCTAssertEqual(description, "The data link could not find this entity")
-                default:
-                    XCTFail()
+        store.find("sample-id", options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .dataLinkEntityNotFound(_, _, let debug, let description):
+                        XCTAssertEqual(debug, "Error: Not Found")
+                        XCTAssertEqual(description, "The data link could not find this entity")
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -940,25 +964,27 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person, writePolicy: .forceNetwork) { person, error in
-            XCTAssertNil(person)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                XCTAssertEqual(error.description, MethodNotAllowedError.descriptionValue)
-                XCTAssertEqual(error.debugDescription, MethodNotAllowedError.debugValue)
-                
-                XCTAssertEqual("\(error)", MethodNotAllowedError.descriptionValue)
-                XCTAssertEqual("\(String(describing: error))", MethodNotAllowedError.descriptionValue)
-                XCTAssertEqual("\(String(reflecting: error))", MethodNotAllowedError.debugValue)
-                
-                switch error {
-                case .methodNotAllowed(_, _, let debug, let description):
-                    XCTAssertEqual(description, MethodNotAllowedError.descriptionValue)
-                    XCTAssertEqual(debug, MethodNotAllowedError.debugValue)
-                default:
-                    XCTFail()
+        store.save(person, options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    XCTAssertEqual(error.description, MethodNotAllowedError.descriptionValue)
+                    XCTAssertEqual(error.debugDescription, MethodNotAllowedError.debugValue)
+                    
+                    XCTAssertEqual("\(error)", MethodNotAllowedError.descriptionValue)
+                    XCTAssertEqual("\(String(describing: error))", MethodNotAllowedError.descriptionValue)
+                    XCTAssertEqual("\(String(reflecting: error))", MethodNotAllowedError.debugValue)
+                    
+                    switch error {
+                    case .methodNotAllowed(_, _, let debug, let description):
+                        XCTAssertEqual(description, MethodNotAllowedError.descriptionValue)
+                        XCTAssertEqual(debug, MethodNotAllowedError.debugValue)
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -978,18 +1004,20 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { person, error in
-            XCTAssertNil(person)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .methodNotAllowed(_, _, let debug, let description):
-                    XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
-                    XCTAssertEqual(description, "The method is not allowed for this resource.")
-                default:
-                    XCTFail()
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .methodNotAllowed(_, _, let debug, let description):
+                        XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
+                        XCTAssertEqual(description, "The method is not allowed for this resource.")
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -1353,18 +1381,20 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find("sample-id", readPolicy: .forceNetwork) { person, error in
-            XCTAssertNil(person)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .methodNotAllowed(_, _, let debug, let description):
-                    XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
-                    XCTAssertEqual(description, "The method is not allowed for this resource.")
-                default:
-                    XCTFail()
+        store.find("sample-id", options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .methodNotAllowed(_, _, let debug, let description):
+                        XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
+                        XCTAssertEqual(description, "The method is not allowed for this resource.")
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -1384,18 +1414,20 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationRemove = expectation(description: "Remove")
         
-        store.removeById("sample-id", writePolicy: .forceNetwork) { person, error in
-            XCTAssertNil(person)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .methodNotAllowed(_, _, let debug, let description):
-                    XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
-                    XCTAssertEqual(description, "The method is not allowed for this resource.")
-                default:
-                    XCTFail()
+        store.remove(byId: "sample-id", options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .methodNotAllowed(_, _, let debug, let description):
+                        XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
+                        XCTAssertEqual(description, "The method is not allowed for this resource.")
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -1469,18 +1501,20 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationRemove = expectation(description: "Remove")
         
-        store.remove(writePolicy: .forceNetwork) { count, error in
-            XCTAssertNil(count)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is Kinvey.Error)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .methodNotAllowed(_, _, let debug, let description):
-                    XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
-                    XCTAssertEqual(description, "The method is not allowed for this resource.")
-                default:
-                    XCTFail()
+        store.remove(options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .methodNotAllowed(_, _, let debug, let description):
+                        XCTAssertEqual(debug, "insert' method is not allowed for this collection.")
+                        XCTAssertEqual(description, "The method is not allowed for this resource.")
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -1520,7 +1554,7 @@ class NetworkStoreTests: StoreTestCase {
             ]
         ]
         
-        var _persons: [Person]? = nil
+        var _persons: AnyRandomAccessCollection<Person>? = nil
         
         do {
             mockResponse(json: mockObjs)
@@ -1530,13 +1564,14 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(readPolicy: .forceNetwork) { (persons, error) in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(persons?.count, 2)
-                
-                _persons = persons
+            store.find(options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 2)
+                    _persons = persons
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -1556,11 +1591,13 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationRemove = expectation(description: "Remove")
             
-            store.remove(persons, writePolicy: .forceNetwork) { count, error in
-                XCTAssertNil(count)
-                XCTAssertNotNil(error)
-                
-                XCTAssertTimeoutError(error)
+            store.remove(persons, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure(let error):
+                    XCTAssertTimeoutError(error)
+                }
                 
                 expectationRemove?.fulfill()
             }
@@ -1599,7 +1636,7 @@ class NetworkStoreTests: StoreTestCase {
             ]
         ]
         
-        var _persons: [Person]? = nil
+        var _persons: AnyRandomAccessCollection<Person>? = nil
         
         do {
             mockResponse(json: mockObjs)
@@ -1609,13 +1646,14 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(readPolicy: .forceNetwork) { (persons, error) in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(persons?.count, 2)
-                
-                _persons = persons
+            store.find(options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 2)
+                    _persons = persons
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -1635,11 +1673,13 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationRemove = expectation(description: "Remove")
             
-            store.removeById(persons.map { $0.entityId! }, writePolicy: .forceNetwork) { count, error in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(count, persons.count)
+            store.remove(byIds: persons.map { $0.entityId! }, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let count):
+                    XCTAssertEqual(count, persons.count)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationRemove?.fulfill()
             }
@@ -1678,7 +1718,7 @@ class NetworkStoreTests: StoreTestCase {
             ]
         ]
         
-        var _persons: [Person]? = nil
+        var _persons: AnyRandomAccessCollection<Person>? = nil
         
         do {
             mockResponse(json: mockObjs)
@@ -1688,13 +1728,14 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(readPolicy: .forceNetwork) { (persons, error) in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(persons?.count, 2)
-                
-                _persons = persons
+            store.find(options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 2)
+                    _persons = persons
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -1714,11 +1755,13 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationRemove = expectation(description: "Remove")
             
-            store.remove(byIds: persons.map { $0.entityId! }, writePolicy: .forceNetwork) { count, error in
-                XCTAssertNil(count)
-                XCTAssertNotNil(error)
-                
-                XCTAssertTimeoutError(error)
+            store.remove(byIds: persons.map { $0.entityId! }, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure(let error):
+                    XCTAssertTimeoutError(error)
+                }
                 
                 expectationRemove?.fulfill()
             }
@@ -1737,11 +1780,13 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationRemove = expectation(description: "Remove")
         
-        store.remove(byIds: [], writePolicy: .forceNetwork) { count, error in
-            XCTAssertNil(count)
-            XCTAssertNotNil(error)
-            
-            XCTAssertEqual(error?.localizedDescription, "ids cannot be an empty array")
+        store.remove(byIds: [], options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertEqual(error.localizedDescription, "ids cannot be an empty array")
+            }
             
             expectationRemove?.fulfill()
         }
@@ -1799,11 +1844,13 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationRemove = expectation(description: "Remove")
         
-        store.removeAll(.forceNetwork) { count, error in
-            XCTAssertNil(count)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        store.removeAll(options: Options(writePolicy: .forceNetwork)) {
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationRemove?.fulfill()
         }
@@ -1821,9 +1868,13 @@ class NetworkStoreTests: StoreTestCase {
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(person) { person, error in
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+        store.save(person) {
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationSave?.fulfill()
         }
@@ -1856,8 +1907,8 @@ class NetworkStoreTests: StoreTestCase {
                 readPolicy: .forceNetwork,
                 clientAppVersion: "1.0.0"
             )
-        ) { (result: Result<[Person], Swift.Error>) in
-            switch result {
+        ) {
+            switch $0 {
             case .success(let results):
                 XCTAssertEqual(results.count, 0)
             case .failure(let error):
@@ -1890,8 +1941,8 @@ class NetworkStoreTests: StoreTestCase {
                     "someKey" : "someValue"
                 ]
             )
-        ) { (result: Result<[Person], Swift.Error>) in
-            switch result {
+        ) {
+            switch $0 {
             case .success(let results):
                 XCTAssertEqual(results.count, 0)
             case .failure(let error):
@@ -1925,8 +1976,8 @@ class NetworkStoreTests: StoreTestCase {
         )
         store.find(
             options: options
-        ) { (result: Result<[Person], Swift.Error>) in
-            switch result {
+        ) {
+            switch $0 {
             case .success(let results):
                 XCTAssertEqual(results.count, 0)
             case .failure(let error):
@@ -2029,7 +2080,7 @@ class NetworkStoreTests: StoreTestCase {
                 let personId = UUID().uuidString
                 mockResponse { (request) -> HttpResponse in
                     var json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
-                    json[PersistableIdKey] = personId
+                    json[Entity.CodingKeys.entityId] = personId
                     mockJson = json
                     return HttpResponse(json: json)
                 }
@@ -2042,15 +2093,15 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationSave = expectation(description: "Save")
             
-            store.save(person, writePolicy: .forceNetwork) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.save(person, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.name)
                     if let name = person.name {
                         XCTAssertEqual(name, "C++")
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationSave?.fulfill()
@@ -2080,11 +2131,9 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find(query, readPolicy: .forceNetwork) { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
-                
-                if let persons = persons {
+            store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let persons):
                     XCTAssertGreaterThan(persons.count, 0)
                     XCTAssertNotNil(persons.first)
                     if let person = persons.first {
@@ -2093,6 +2142,8 @@ class NetworkStoreTests: StoreTestCase {
                             XCTAssertEqual(name, "C++")
                         }
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -2126,7 +2177,7 @@ class NetworkStoreTests: StoreTestCase {
                 let personId = UUID().uuidString
                 mockResponse(completionHandler: { (request) -> HttpResponse in
                     var json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
-                    json[PersistableIdKey] = personId
+                    json[Entity.CodingKeys.entityId] = personId
                     mockJson = json
                     return HttpResponse(json: json)
                 })
@@ -2139,16 +2190,16 @@ class NetworkStoreTests: StoreTestCase {
             
             weak var expectationSave = expectation(description: "Save")
             
-            store.save(person, writePolicy: .forceNetwork) { person, error in
-                XCTAssertNotNil(person)
-                XCTAssertNil(error)
-                
-                if let person = person {
+            store.save(person, options: Options(writePolicy: .forceNetwork)) {
+                switch $0 {
+                case .success(let person):
                     XCTAssertNotNil(person.geolocation)
                     if let geolocation = person.geolocation {
                         XCTAssertEqual(geolocation.latitude, latitude)
                         XCTAssertEqual(geolocation.longitude, longitude)
                     }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationSave?.fulfill()
@@ -2173,16 +2224,16 @@ class NetworkStoreTests: StoreTestCase {
                 
                 weak var expectationFind = expectation(description: "Find")
                 
-                store.find(byId: personId, readPolicy: .forceNetwork) { person, error in
-                    XCTAssertNotNil(person)
-                    XCTAssertNil(error)
-                    
-                    if let person = person {
+                store.find(personId, options: Options(readPolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success(let person):
                         XCTAssertNotNil(person.geolocation)
                         if let geolocation = person.geolocation {
                             XCTAssertEqual(geolocation.latitude, latitude)
                             XCTAssertEqual(geolocation.longitude, longitude)
                         }
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationFind?.fulfill()
@@ -2231,11 +2282,9 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceNetwork) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNotNil(persons.first)
                         if let person = persons.first {
                             XCTAssertNotNil(person.geolocation)
@@ -2244,6 +2293,8 @@ class NetworkStoreTests: StoreTestCase {
                                 XCTAssertEqual(geolocation.longitude, longitude)
                             }
                         }
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2257,11 +2308,9 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceLocal) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceLocal)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNotNil(persons.first)
                         if let person = persons.first {
                             XCTAssertNotNil(person.geolocation)
@@ -2270,6 +2319,8 @@ class NetworkStoreTests: StoreTestCase {
                                 XCTAssertEqual(geolocation.longitude, longitude)
                             }
                         }
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2287,12 +2338,12 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceNetwork) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNil(persons.first)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2306,12 +2357,12 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceLocal) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceLocal)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNil(persons.first)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2380,11 +2431,9 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceNetwork) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNotNil(persons.first)
                         if let person = persons.first {
                             XCTAssertNotNil(person.geolocation)
@@ -2393,6 +2442,8 @@ class NetworkStoreTests: StoreTestCase {
                                 XCTAssertEqual(geolocation.longitude, longitude)
                             }
                         }
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2406,11 +2457,9 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceLocal) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceLocal)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNotNil(persons.first)
                         if let person = persons.first {
                             XCTAssertNotNil(person.geolocation)
@@ -2419,6 +2468,8 @@ class NetworkStoreTests: StoreTestCase {
                                 XCTAssertEqual(geolocation.longitude, longitude)
                             }
                         }
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2444,12 +2495,12 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceNetwork) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceNetwork)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNil(persons.first)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2463,12 +2514,12 @@ class NetworkStoreTests: StoreTestCase {
             do {
                 weak var expectationQuery = expectation(description: "Query")
                 
-                store.find(query, readPolicy: .forceLocal) { persons, error in
-                    XCTAssertNotNil(persons)
-                    XCTAssertNil(error)
-                    
-                    if let persons = persons {
+                store.find(query, options: Options(readPolicy: .forceLocal)) {
+                    switch $0 {
+                    case .success(let persons):
                         XCTAssertNil(persons.first)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationQuery?.fulfill()
@@ -2503,13 +2554,16 @@ class NetworkStoreTests: StoreTestCase {
             initialObject: ["sum" : 0],
             reduceJSFunction: "function(doc,out) { out.sum += doc.age; }",
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let (person, result) = results?.first {
-                XCTAssertNil(person.name)
-                XCTAssertNotNil(result["sum"] as? Int)
+        ) {
+            switch $0 {
+            case .success(let results):
+                XCTAssertGreaterThan(results.count, 0)
+                if let (person, result) = results.first {
+                    XCTAssertNil(person.name)
+                    XCTAssertNotNil(result["sum"] as? Int)
+                }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2616,13 +2670,16 @@ class NetworkStoreTests: StoreTestCase {
             initialObject: ["sum" : 0],
             reduceJSFunction: "function(doc,out) { out.sum += doc.age; }",
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let (person, result) = results?.first {
-                XCTAssertNotNil(person.name)
-                XCTAssertNotNil(result["sum"] as? Int)
+        ) {
+            switch $0 {
+            case .success(let results):
+                XCTAssertGreaterThan(results.count, 0)
+                if let (person, result) = results.first {
+                    XCTAssertNotNil(person.name)
+                    XCTAssertNotNil(result["sum"] as? Int)
+                }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2649,11 +2706,13 @@ class NetworkStoreTests: StoreTestCase {
             initialObject: ["sum" : 0],
             reduceJSFunction: "function(doc,out) { out.sum += doc.age; }",
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNil(results)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -2688,17 +2747,17 @@ class NetworkStoreTests: StoreTestCase {
             count: ["name"],
             countType: Int.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        ) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertGreaterThanOrEqual(results.count, 0)
                 
                 if let first = results.first {
                     XCTAssertNotNil(first.value.name)
                     XCTAssertEqual(first.count, 32)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2725,11 +2784,13 @@ class NetworkStoreTests: StoreTestCase {
             count: ["name"],
             countType: Int.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNil(results)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -2765,17 +2826,17 @@ class NetworkStoreTests: StoreTestCase {
             sum: "age",
             sumType: Double.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        ) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertGreaterThanOrEqual(results.count, 0)
                 
                 if let first = results.first {
                     XCTAssertNotNil(first.value.name)
                     XCTAssertEqual(first.sum, 926.2)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2803,11 +2864,13 @@ class NetworkStoreTests: StoreTestCase {
             sum: "age",
             sumType: Double.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (results, error) in
-            XCTAssertNil(results)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -2845,17 +2908,17 @@ class NetworkStoreTests: StoreTestCase {
             avg: "age",
             avgType: Double.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNotNil(result)
-            XCTAssertNil(error)
-            
-            if let result = result {
+        ) {
+            switch $0 {
+            case .success(let result):
                 XCTAssertGreaterThanOrEqual(result.count, 0)
                 
                 if let first = result.first {
                     XCTAssertNotNil(first.value.name)
                     XCTAssertEqual(first.avg, 28.9375)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2883,11 +2946,13 @@ class NetworkStoreTests: StoreTestCase {
             avg: "age",
             avgType: Double.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNil(result)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -2923,17 +2988,17 @@ class NetworkStoreTests: StoreTestCase {
             min: "age",
             minType: Double.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNotNil(result)
-            XCTAssertNil(error)
-            
-            if let result = result {
+        ) {
+            switch $0 {
+            case .success(let result):
                 XCTAssertGreaterThanOrEqual(result.count, 0)
                 
                 if let (person, min) = result.first {
                     XCTAssertNotNil(person.name)
                     XCTAssertEqual(min, 27.6)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -2961,11 +3026,13 @@ class NetworkStoreTests: StoreTestCase {
             min: "age",
             minType: Float.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNil(result)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -3001,17 +3068,17 @@ class NetworkStoreTests: StoreTestCase {
             max: "age",
             maxType: Float.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNotNil(result)
-            XCTAssertNil(error)
-            
-            if let result = result {
+        ) {
+            switch $0 {
+            case .success(let result):
                 XCTAssertGreaterThanOrEqual(result.count, 0)
                 
                 if let (person, max) = result.first {
                     XCTAssertNotNil(person.name)
                     XCTAssertEqual(max, 30.5)
                 }
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationGroup?.fulfill()
@@ -3039,11 +3106,13 @@ class NetworkStoreTests: StoreTestCase {
             max: "age",
             maxType: Float.self,
             condition: NSPredicate(format: "age > %@", NSNumber(value: 18))
-        ) { (result, error) in
-            XCTAssertNil(result)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTimeoutError(error)
+        ) {
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTimeoutError(error)
+            }
             
             expectationGroup?.fulfill()
         }
@@ -3062,7 +3131,7 @@ class NetworkStoreTests: StoreTestCase {
     func testRemoveByEmptyId() {
         let store = DataStore<Person>.collection(.network)
         expect { () -> Void in
-            store.remove(byId: "") { count, error in
+            store.remove(byId: "") { _ in
                 XCTFail()
             }
         }.to(throwAssertion())
@@ -3373,8 +3442,8 @@ class NetworkStoreTests: StoreTestCase {
     }
     
     func testDataStoreCacheInstances() {
-        let ds1 = DataStore<Person>.collection(.network, deltaSet: true)
-        let ds2 = DataStore<Person>.collection(.network, deltaSet: false)
+        let ds1 = DataStore<Person>.collection(.network, options: Options(deltaSet: true))
+        let ds2 = DataStore<Person>.collection(.network, options: Options(deltaSet: false))
         XCTAssertTrue(ds1.deltaSet)
         XCTAssertFalse(ds2.deltaSet)
         

--- a/Kinvey/KinveyTests/NoCacheTestCase.swift
+++ b/Kinvey/KinveyTests/NoCacheTestCase.swift
@@ -35,7 +35,14 @@ class NoCacheTestCase: XCTestCase {
     
     func testNoCache() {
         let appKey = "noCacheAppKey"
-        Kinvey.sharedClient.initialize(appKey: appKey, appSecret: "noCacheAppSecret")
+        Kinvey.sharedClient.initialize(appKey: appKey, appSecret: "noCacheAppSecret") {
+            switch $0 {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
         
         let dataStore = DataStore<Person>.collection(.network)
         
@@ -55,8 +62,8 @@ class NoCacheTestCase: XCTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        dataStore.find(options: nil) { (result: Result<[Person], Swift.Error>) in
-            switch result {
+        dataStore.find {
+            switch $0 {
             case .success:
                 break
             case .failure(let error):

--- a/Kinvey/KinveyTests/PerformanceProductTestCase.swift
+++ b/Kinvey/KinveyTests/PerformanceProductTestCase.swift
@@ -93,7 +93,7 @@ class PerformanceProductTestCase: KinveyTestCase {
     
     var productsJsonArray: [JsonDictionary]?
     
-    lazy var fileStore = FileStore.getInstance()
+    lazy var fileStore = FileStore()
     
     lazy var productsJsonFile: File? = {
         var productsJsonFile: File?
@@ -168,11 +168,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         
         weak var expectationCount = self.expectation(description: "Count")
         
-        store.count { (_count, error) in
-            count = _count
-            
-            XCTAssertNotNil(count)
-            XCTAssertNil(error)
+        store.count {
+            switch $0 {
+            case .success(let _count):
+                count = _count
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
             
             expectationCount?.fulfill()
         }
@@ -269,9 +271,13 @@ class PerformanceProductTestCase: KinveyTestCase {
             while query.skip! + query.limit! < self.count! {
                 weak var expectationFind = self.expectation(description: "Find")
                 
-                store.find(query) { (products, error) in
-                    XCTAssertNotNil(products)
-                    XCTAssertNil(error)
+                store.find(query) {
+                    switch $0 {
+                    case .success(let products):
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationFind?.fulfill()
                 }
@@ -298,9 +304,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         for productJson in self.productsJsonArray![skip ..< count] {
             if let product = Product(JSON: productJson) {
                 let promise = Promise<Void> { resolver in
-                    store.save(product) { product, error in
-                        XCTAssertNotNil(product)
-                        XCTAssertNil(error)
+                    store.save(product) {
+                        switch $0 {
+                        case .success(let product):
+                            break
+                        case .failure(let error):
+                            XCTFail(error.localizedDescription)
+                        }
                         
                         resolver.fulfill(())
                     }
@@ -342,9 +352,13 @@ class PerformanceProductTestCase: KinveyTestCase {
             while query.skip! + query.limit! < self.count! {
                 weak var expectationFind = self.expectation(description: "Find")
                 
-                store.find(query) { (products, error) in
-                    XCTAssertNotNil(products)
-                    XCTAssertNil(error)
+                store.find(query) {
+                    switch $0 {
+                    case .success(let products):
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationFind?.fulfill()
                 }
@@ -369,13 +383,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         self.measure {
             weak var expectationFind = self.expectation(description: "Find")
             
-            store.find(query) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
-                
-                if let products = products {
+            store.find(query) {
+                switch $0 {
+                case .success(let products):
                     XCTAssertGreaterThan(products.count, 0)
                     XCTAssertLessThanOrEqual(products.count, query.limit!)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -401,15 +415,15 @@ class PerformanceProductTestCase: KinveyTestCase {
             weak var expectationFindLocal = self.expectation(description: "Find Local")
             weak var expectationFindNetwork = self.expectation(description: "Find Network")
             
-            store.find(query) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
-                
-                if let products = products {
+            store.find(query) {
+                switch $0 {
+                case .success(let products):
                     if expectationFindLocal == nil {
                         XCTAssertGreaterThan(products.count, 0)
                     }
                     XCTAssertLessThanOrEqual(products.count, query.limit!)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 if expectationFindLocal != nil {
@@ -441,15 +455,15 @@ class PerformanceProductTestCase: KinveyTestCase {
             weak var expectationFindLocal = self.expectation(description: "Find Local")
             weak var expectationFindNetwork = self.expectation(description: "Find Network")
             
-            store.find(query, readPolicy: .both) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
-                
-                if let products = products {
+            store.find(query, options: Options(readPolicy: .both)) {
+                switch $0 {
+                case .success(let products):
                     if expectationFindLocal == nil {
                         XCTAssertGreaterThan(products.count, 0)
                     }
                     XCTAssertLessThanOrEqual(products.count, query.limit!)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 if expectationFindLocal != nil {
@@ -474,13 +488,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         self.measure {
             weak var expectationFind = self.expectation(description: "Find")
             
-            store.find(query) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
-                
-                if let products = products {
+            store.find(query) {
+                switch $0 {
+                case .success(let products):
                     XCTAssertGreaterThan(products.count, 0)
                     XCTAssertLessThanOrEqual(products.count, query.limit!)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 
                 expectationFind?.fulfill()
@@ -505,9 +519,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         self.measure {
             weak var expectationFind = self.expectation(description: "Find")
             
-            store.find(query, deltaSet: true) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
+            store.find(query, options: Options(deltaSet: true)) {
+                switch $0 {
+                case .success(let products):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -552,9 +570,13 @@ class PerformanceProductTestCase: KinveyTestCase {
         self.measure {
             weak var expectationFind = self.expectation(description: "Find")
             
-            store.find(query) { (products, error) in
-                XCTAssertNotNil(products)
-                XCTAssertNil(error)
+            store.find(query) {
+                switch $0 {
+                case .success(let products):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -583,9 +605,13 @@ class PerformanceProductTestCase: KinveyTestCase {
                 
                 weak var expectationSave = self.expectation(description: "Save")
                 
-                store.save(product) { (product, error) in
-                    XCTAssertNotNil(product)
-                    XCTAssertNil(error)
+                store.save(product) {
+                    switch $0 {
+                    case .success(let product):
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationSave?.fulfill()
                 }
@@ -632,9 +658,13 @@ class PerformanceProductTestCase: KinveyTestCase {
                 
                 weak var expectationSave = self.expectation(description: "Save")
                 
-                store.save(product) { (product, error) in
-                    XCTAssertNotNil(product)
-                    XCTAssertNil(error)
+                store.save(product) {
+                    switch $0 {
+                    case .success(let product):
+                        break
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
+                    }
                     
                     expectationSave?.fulfill()
                 }

--- a/Kinvey/KinveyTests/PerformanceTestCase.swift
+++ b/Kinvey/KinveyTests/PerformanceTestCase.swift
@@ -42,17 +42,17 @@ class PerformanceTestCase: StoreTestCase {
                 expectationPush = nil
             }
             
-            let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator ==  %@", user.userId)
+            let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator ==  %@", user.userId)
             
             self.measure {
                 weak var expectationFind = self.expectation(description: "Find")
                 
-                self.store.find(query, deltaSet: false) { results, error in
-                    XCTAssertNotNil(results)
-                    XCTAssertNil(error)
-                    
-                    if let results = results {
+                self.store.find(query, options: Options(deltaSet: false)) {
+                    switch $0 {
+                    case .success(let results):
                         XCTAssertEqual(results.count, n)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationFind?.fulfill()
@@ -96,17 +96,17 @@ class PerformanceTestCase: StoreTestCase {
                 expectationPush = nil
             }
             
-            let query = Query(format: "\(Person.aclProperty() ?? PersistableAclKey).creator ==  %@", user.userId)
+            let query = Query(format: "\(Person.aclProperty() ?? Person.CodingKeys.acl.rawValue).creator ==  %@", user.userId)
             
             self.measure {
                 weak var expectationFind = self.expectation(description: "Find")
                 
-                self.store.find(query, deltaSet: false) { results, error in
-                    XCTAssertNotNil(results)
-                    XCTAssertNil(error)
-                    
-                    if let results = results {
+                self.store.find(query, options: Options(deltaSet: false)) {
+                    switch $0 {
+                    case .success(let results):
                         XCTAssertEqual(results.count, n)
+                    case .failure(let error):
+                        XCTFail(error.localizedDescription)
                     }
                     
                     expectationFind?.fulfill()

--- a/Kinvey/KinveyTests/PersistableTestCase.swift
+++ b/Kinvey/KinveyTests/PersistableTestCase.swift
@@ -54,12 +54,12 @@ class PersistableTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -114,12 +114,12 @@ class PersistableTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -172,12 +172,12 @@ class PersistableTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()
@@ -231,12 +231,12 @@ class PersistableTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(readPolicy: .forceNetwork) { (results, error) in
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
-            
-            if let results = results {
+        store.find(options: Options(readPolicy: .forceNetwork)) {
+            switch $0 {
+            case .success(let results):
                 XCTAssertEqual(results.count, 1)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationFind?.fulfill()

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -62,7 +62,7 @@ class Person: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        personId <- ("personId", map[PersistableIdKey])
+        personId <- ("personId", map[Entity.CodingKeys.entityId])
         name <- ("name", map["name"])
         age <- ("age", map["age"])
         address <- ("address", map["address"], AddressTransform())
@@ -103,7 +103,7 @@ class PersonWithDifferentClassName: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        personId <- ("personId", map[PersistableIdKey])
+        personId <- ("personId", map[Entity.CodingKeys.entityId])
         name <- ("name", map["name"])
         age <- ("age", map["age"])
         address <- ("address", map["address"], AddressTransform())

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -73,12 +73,11 @@ class QueryTest: XCTestCase {
                 setURLProtocol(nil)
             }
             
-            let dataStore = DataStore<Person>.collection(.network, client: client)
+            let dataStore = DataStore<Person>.collection(.network, options: Options(client: client))
             let query = Query(format: "obj._id == %@", 30)
             
             weak var expectationFind = expectation(description: "Find")
-            
-            dataStore.find(query, options: Options(client: client)) { (result: Result<[Person], Swift.Error>) in
+            dataStore.find(query, options: Options(client: client)) { (result: Result<AnyRandomAccessCollection<Person>, Swift.Error>) in
                 switch result {
                 case .success(let persons):
                     XCTAssertEqual(persons.count, 0)

--- a/Kinvey/KinveyTests/RealtimeTestCase.swift
+++ b/Kinvey/KinveyTests/RealtimeTestCase.swift
@@ -927,7 +927,7 @@ class RealtimeTestCase: KinveyTestCase {
             
             let query = Query(format: "_id != %@", user.userId)
             query.limit = 2
-            user.find(query: query, client: client) {
+            user.find(query: query, options: Options(client: client)) {
                 switch $0 {
                 case .success(let users):
                     usersArray = users
@@ -1225,7 +1225,7 @@ class RealtimeTestCase: KinveyTestCase {
             
             let query = Query(format: "_id != %@", user.userId)
             query.limit = 2
-            user.find(query: query, client: client) {
+            user.find(query: query, options: Options(client: client)) {
                 switch $0 {
                 case .success(let users):
                     usersArray = users
@@ -1417,7 +1417,7 @@ class RealtimeTestCase: KinveyTestCase {
             
             let query = Query(format: "_id != %@", user.userId)
             query.limit = 2
-            user.find(query: query, client: client) {
+            user.find(query: query, options: Options(client: client)) {
                 switch $0 {
                 case .success(let users):
                     usersArray = users

--- a/Kinvey/KinveyTests/RefProject.swift
+++ b/Kinvey/KinveyTests/RefProject.swift
@@ -25,7 +25,7 @@ class RefProject: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        uniqueId <- map[PersistableIdKey]
+        uniqueId <- map[Entity.CodingKeys.entityId]
         name <- map["name"]
     }
     

--- a/Kinvey/KinveyTests/StoreTestCase.swift
+++ b/Kinvey/KinveyTests/StoreTestCase.swift
@@ -54,16 +54,16 @@ class StoreTestCase: KinveyTestCase {
         
         var savedPersistable: T? = nil
         
-        store.save(persistable) { (persistable, error) -> Void in
+        store.save(persistable) {
             self.assertThread()
-            XCTAssertNotNil(persistable)
-            XCTAssertNil(error)
-            
-            if let persistable = persistable {
+            switch $0 {
+            case .success(let persistable):
                 XCTAssertNotNil(persistable.entityId)
+                
+                savedPersistable = persistable
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
-            
-            savedPersistable = persistable
             
             expectationCreate?.fulfill()
         }
@@ -101,17 +101,17 @@ class StoreTestCase: KinveyTestCase {
         
         weak var expectationCreate = expectation(description: "Create")
         
-        store.save(person) { (person, error) -> Void in
+        store.save(person) {
             self.assertThread()
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
-            
-            if let person = person {
+            switch $0 {
+            case .success(let person):
                 XCTAssertNotNil(person.personId)
                 XCTAssertNotEqual(person.personId, "")
                 
                 XCTAssertNotNil(person.age)
                 XCTAssertEqual(person.age, age)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             
             expectationCreate?.fulfill()
@@ -130,10 +130,15 @@ class StoreTestCase: KinveyTestCase {
         
         weak var expectationCreate = expectation(description: "Create")
         
-        store.save(person) { (person, error) -> Void in
+        store.save(person) {
             self.assertThread()
-            XCTAssertNotNil(person)
-            XCTAssertNil(error)
+            switch $0 {
+            case .success(let person):
+                break
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            
             expectationCreate?.fulfill()
         }
         

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -183,7 +183,7 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, client: client) {
+            User.destroy(userId: user.userId, options: Options(client: client)) {
                 XCTAssertTrue(Thread.isMainThread)
                 
                 switch $0 {
@@ -219,7 +219,7 @@ class UserTests: KinveyTestCase {
             
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, hard: true, client: client) {
+            User.destroy(userId: user.userId, hard: true, options: Options(client: client)) {
                 XCTAssertTrue(Thread.isMainThread)
                 
                 switch $0 {
@@ -255,7 +255,7 @@ class UserTests: KinveyTestCase {
             
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, hard: false, client: client) {
+            User.destroy(userId: user.userId, hard: false, options: Options(client: client)) {
                 XCTAssertTrue(Thread.isMainThread)
                 
                 switch $0 {
@@ -291,7 +291,7 @@ class UserTests: KinveyTestCase {
             
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, hard: true, client: client) {
+            User.destroy(userId: user.userId, hard: true, options: Options(client: client)) {
                 XCTAssertTrue(Thread.isMainThread)
                 
                 switch $0 {
@@ -322,9 +322,8 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, client: client, completionHandler: {
+            User.destroy(userId: user.userId, options: Options(client: client)) {
                 XCTAssertTrue(Thread.isMainThread)
-                
                 
                 switch $0 {
                 case .success:
@@ -334,7 +333,7 @@ class UserTests: KinveyTestCase {
                 }
                 
                 expectationDestroyUser?.fulfill()
-            })
+            }
             
             waitForExpectations(timeout: defaultTimeout) { error in
                 expectationDestroyUser = nil
@@ -405,10 +404,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find() { results, error in
+            store.find {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let results):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -472,10 +475,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find() { results, error in
+            store.find() {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let results):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -514,10 +521,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find() { results, error in
+            store.find {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success(let results):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -576,10 +587,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find() { results, error in
+            store.find {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -703,8 +718,8 @@ class UserTests: KinveyTestCase {
                 options: Options(
                     client: client
                 )
-            ) { (result: Result<[Person], Swift.Error>) in
-                switch result {
+            ) {
+                switch $0 {
                 case .success:
                     break
                 case .failure:
@@ -1765,9 +1780,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            User.resetPassword(username: user.username!) { error in
+            User.resetPassword(usernameOrEmail: user.username!, options: nil) {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -1795,11 +1815,12 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            User.resetPassword(email: user.username!) { error in
+            User.resetPassword(usernameOrEmail: user.username!, options: nil) {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(error)
-                
-                if let error = error {
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure(let error):
                     XCTAssertTimeoutError(error)
                 }
                 
@@ -1831,9 +1852,14 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            User.resetPassword(email: user.email!) { error in
+            User.resetPassword(usernameOrEmail: user.email!, options: nil) {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -2299,9 +2325,13 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find() { results, error in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+            store.find {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -2520,9 +2550,13 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
+            store.find {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -2745,9 +2779,13 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find { persons, error in
-                XCTAssertNotNil(persons)
-                XCTAssertNil(error)
+            store.find {
+                switch $0 {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -2920,9 +2958,13 @@ class UserTests: KinveyTestCase {
             
             weak var expectationFind = expectation(description: "Find")
             
-            store.find { persons, error in
-                XCTAssertNil(persons)
-                XCTAssertNotNil(error)
+            store.find {
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure:
+                    break
+                }
                 
                 expectationFind?.fulfill()
             }
@@ -3797,10 +3839,14 @@ extension UserTests {
                     
                     weak var expectationFind = expectation(description: "Find")
                     
-                    store.find { persons, error in
+                    store.find {
                         XCTAssertTrue(Thread.isMainThread)
-                        XCTAssertNil(error)
-                        XCTAssertNotNil(persons)
+                        switch $0 {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            XCTFail(error.localizedDescription)
+                        }
                         
                         expectationFind?.fulfill()
                     }
@@ -4033,21 +4079,24 @@ extension UserTests {
         weak var expectationLogin = expectation(description: "Login")
         
         let redirectURI = URL(string: "throwAnError://")!
-        User.presentMICViewController(redirectURI: redirectURI, timeout: 60, forceUIWebView: true) { (user, error) -> Void in
+        
+        User.presentMICViewController(redirectURI: redirectURI, micUserInterface: .uiWebView, options: Options(timeout: 60)) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(error)
-            XCTAssertNotNil(error as? Kinvey.Error)
-            XCTAssertNil(user)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .unknownJsonError(_, _, let json):
-                    XCTAssertEqual(json.count, responseBody.count)
-                    XCTAssertEqual(json["error"] as? String, responseBody["error"])
-                    XCTAssertEqual(json["error_description"] as? String, responseBody["error_description"])
-                    XCTAssertEqual(json["debug"] as? String, responseBody["debug"])
-                default:
-                    XCTFail()
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertNotNil(error as? Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .unknownJsonError(_, _, let json):
+                        XCTAssertEqual(json.count, responseBody.count)
+                        XCTAssertEqual(json["error"] as? String, responseBody["error"])
+                        XCTAssertEqual(json["error_description"] as? String, responseBody["error_description"])
+                        XCTAssertEqual(json["debug"] as? String, responseBody["debug"])
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -4075,21 +4124,23 @@ extension UserTests {
         weak var expectationLogin = expectation(description: "Login")
         
         let redirectURI = URL(string: "throwAnError://")!
-        User.presentMICViewController(redirectURI: redirectURI, timeout: 60, forceUIWebView: false) { (user, error) -> Void in
+        User.presentMICViewController(redirectURI: redirectURI, micUserInterface: .wkWebView, options: Options(timeout: 60)) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(error)
-            XCTAssertNotNil(error as? Kinvey.Error)
-            XCTAssertNil(user)
-            
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .unknownJsonError(_, _, let json):
-                    XCTAssertEqual(json.count, responseBody.count)
-                    XCTAssertEqual(json["error"] as? String, responseBody["error"])
-                    XCTAssertEqual(json["error_description"] as? String, responseBody["error_description"])
-                    XCTAssertEqual(json["debug"] as? String, responseBody["debug"])
-                default:
-                    XCTFail()
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertNotNil(error as? Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .unknownJsonError(_, _, let json):
+                        XCTAssertEqual(json.count, responseBody.count)
+                        XCTAssertEqual(json["error"] as? String, responseBody["error"])
+                        XCTAssertEqual(json["error_description"] as? String, responseBody["error_description"])
+                        XCTAssertEqual(json["debug"] as? String, responseBody["debug"])
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -4145,7 +4196,7 @@ extension UserTests {
         let result = User.login(
             redirectURI: URL(string: "myCustomURIScheme://")!,
             micURL: URL(string: "myCustomURIScheme://?code=1234")!,
-            client: client
+            options: Options(client: client)
         )
         XCTAssertTrue(result)
         
@@ -4157,7 +4208,7 @@ extension UserTests {
         let result = User.login(
             redirectURI: URL(string: "myCustomURIScheme://")!,
             micURL: URL(string: "myCustomURIScheme://?no_code=1234")!,
-            client: client
+            options: Options(client: client)
         )
         XCTAssertFalse(result)
     }
@@ -4217,7 +4268,7 @@ extension UserTests {
         let result = User.login(
             redirectURI: URL(string: "myCustomURIScheme://")!,
             micURL: URL(string: "myCustomURIScheme://?code=1234")!,
-            client: client
+            options: Options(client: client)
         )
         XCTAssertTrue(result)
         
@@ -4295,7 +4346,7 @@ extension UserTests {
         let result = User.login(
             redirectURI: URL(string: "myCustomURIScheme://")!,
             micURL: URL(string: "myCustomURIScheme://?code=1234")!,
-            client: client
+            options: Options(client: client)
         )
         XCTAssertTrue(result)
         
@@ -4323,19 +4374,22 @@ extension UserTests {
         let redirectURI = URL(string: "throwAnError://")!
         User.presentMICViewController(
             redirectURI: redirectURI,
-            timeout: 3,
-            forceUIWebView: true
-        ) { (user, error) -> Void in
+            micUserInterface: .uiWebView,
+            options: Options(timeout: 3)
+        ) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTrue(error is Kinvey.Error)
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .requestTimeout:
-                    break
-                default:
-                    XCTFail()
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .requestTimeout:
+                        break
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             
@@ -4362,17 +4416,24 @@ extension UserTests {
         weak var expectationLogin = expectation(description: "Login")
         
         let redirectURI = URL(string: "throwAnError://")!
-        User.presentMICViewController(redirectURI: redirectURI, timeout: 60, forceUIWebView: true) { (user, error) -> Void in
+        User.presentMICViewController(
+            redirectURI: redirectURI,
+            micUserInterface: .uiWebView,
+            options: Options(timeout: 60)
+        ) {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(error)
-            
-            XCTAssertTrue(error is Kinvey.Error)
-            if let error = error as? Kinvey.Error {
-                switch error {
-                case .requestCancelled:
-                    break
-                default:
-                    XCTFail()
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .requestCancelled:
+                        break
+                    default:
+                        XCTFail()
+                    }
                 }
             }
             

--- a/Kinvey/RealtimeSender/ViewController.swift
+++ b/Kinvey/RealtimeSender/ViewController.swift
@@ -90,7 +90,16 @@ class ViewController: NSViewController {
             appKey: appKey!,
             appSecret: appSecret!,
             apiHostName: hostURL ?? Client.defaultApiHostName
-        )
+        ) {
+            switch $0 {
+            case .success(let user):
+                if let user = user {
+                    print(user)
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
         
         guard let _ = username else {
             fatalError("username missing")
@@ -153,9 +162,9 @@ class ViewController: NSViewController {
         User.login(
             username: username!,
             password: password!,
-            client: sharedClient
-        ) { (result: Result<User, Swift.Error>) in
-            switch result {
+            options: Options(client: sharedClient)
+        ) {
+            switch $0 {
             case .success(let user):
                 print("Login Succeed")
                 registerForRealtime(user: user)


### PR DESCRIPTION
#### Description

Removing Deprecated methods

#### Changes

- Removing Deprecated methods
- Adding missing deprecations, so we can remove in the next minor version

#### Tests

- Tests are the same, but lots of changes were required to since many old unit test were using deprecated methods
