### PR TITLE
MLIBZ-1937: returning support for tvOS for CocoaPods

### DIFF
--- a/Kinvey.podspec
+++ b/Kinvey.podspec
@@ -70,7 +70,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.12"
   s.watchos.deployment_target = "2.2"
-  # s.tvos.deployment_target = "9.2"
+  s.tvos.deployment_target = "9.2"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
#### Description

Testing this again I actually figured the problem is actually a bug in CocoaPods that is solved after clear the CocoaPods cache folder like described here:

https://github.com/realm/realm-cocoa/issues/4758

#### Changes

- `Kinvey.podspec` file to support tvOS again for CocoaPods

#### Tests

- No need
