### PR TITLE
MLIBZ-2557: adding missing methods to be deprecated

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -428,6 +428,7 @@ open class Client: Credential {
      call to the server.
      */
     @discardableResult
+    @available(*, deprecated: 3.17.1, message: "Please use Client.ping(completionHandler:) instead")
     public func ping(completionHandler: @escaping (EnvironmentInfo?, Swift.Error?) -> Void) -> AnyRequest<Result<EnvironmentInfo, Swift.Error>> {
         return ping() { (result: Result<EnvironmentInfo, Swift.Error>) in
             switch result {

--- a/Kinvey/Kinvey/Push.swift
+++ b/Kinvey/Kinvey/Push.swift
@@ -22,6 +22,7 @@ import ObjectiveC
 /// Class used to register and unregister a device to receive push notifications.
 open class Push {
     
+    @available(*, deprecated: 3.17.1, message: "Please use Result<Bool, Swift.Error> instead")
     public typealias BoolCompletionHandler = (Bool, Swift.Error?) -> Void
     
     fileprivate let client: Client


### PR DESCRIPTION
#### Description

Deprecating methods that should be already deprecated a long time ago

#### Changes

- `Client` and `Push`

#### Tests

- No need
