### PR TITLE
MLIBZ-2582: fix for DataStore.removeAll() memory leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
 # - brew upgrade carthage
 - tree -L 2 -P '*.framework' -I '*.dSYM' Carthage/Build
 - carthage version
+- xcpretty --version
 - if [ ! -d $( md5 Cartfile.resolved | awk '{ print "Carthage/" $4 ".zip" }' ) ]; then
     make travisci-cache;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ script:
 - set -o pipefail;
   case $PLATFORM in
   iOS)
-    travis_wait 30 make test-ios;;
+    travis_retry make test-ios;;
   Mac)
-    travis_wait 30 make test-macos;;
+    travis_retry make test-macos;;
   esac
 after_script:
 - date

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ script:
 - set -o pipefail;
   case $PLATFORM in
   iOS)
-    travis_retry make test-ios | xcpretty;;
+    travis_wait 30 make test-ios | xcpretty;;
   Mac)
-    travis_retry make test-macos | xcpretty;;
+    travis_wait 30 make test-macos | xcpretty;;
   esac
 after_script:
 - date

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ script:
 - set -o pipefail;
   case $PLATFORM in
   iOS)
-    travis_retry make test-ios;;
+    travis_retry make test-ios | xcpretty;;
   Mac)
-    travis_retry make test-macos;;
+    travis_retry make test-macos | xcpretty;;
   esac
 after_script:
 - date

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ script:
 - set -o pipefail;
   case $PLATFORM in
   iOS)
-    travis_wait 30 make test-ios | xcpretty;;
+    travis_wait 30 make test-ios;;
   Mac)
-    travis_wait 30 make test-macos | xcpretty;;
+    travis_wait 30 make test-macos;;
   esac
 after_script:
 - date

--- a/Kinvey/Kinvey/Executor.swift
+++ b/Kinvey/Kinvey/Executor.swift
@@ -19,11 +19,21 @@ class Executor {
         thread = Thread.current
     }
     
-    func execute(_ block: @escaping () -> Void) {
+    func execute(_ _block: @escaping () -> Void) {
+        let block = {
+            autoreleasepool {
+                _block()
+            }
+        }
         operationQueue.addOperation(block)
     }
     
-    func executeAndWait(_ block: @escaping () -> Void) {
+    func executeAndWait(_ _block: @escaping () -> Void) {
+        let block = {
+            autoreleasepool {
+                _block()
+            }
+        }
         if thread == Thread.current {
             block()
         } else {

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -308,3 +308,29 @@ func buildError(
         data: data
     )
 }
+
+extension Sequence {
+    
+    func forEachAutoreleasepool(_ block: (Element) throws -> Swift.Void) rethrows {
+        try forEach { x in
+            try autoreleasepool {
+                try block(x)
+            }
+        }
+    }
+    
+}
+
+fileprivate func autoreleasepool(_ condition: @autoclosure () -> Bool) -> Bool {
+    return autoreleasepool {
+        return condition()
+    }
+}
+
+func whileAutoreleasepool(_ condition: @autoclosure () -> Bool, _ block: () throws -> Void) rethrows {
+    while autoreleasepool(condition) {
+        try autoreleasepool {
+            try block()
+        }
+    }
+}

--- a/Kinvey/Kinvey/RemoveOperation.swift
+++ b/Kinvey/Kinvey/RemoveOperation.swift
@@ -42,15 +42,11 @@ class RemoveOperation<T: Persistable>: WriteOperation<T, Int>, WriteOperationTyp
                 let realmObjects = cache.find(byQuery: self.query)
                 count = Int(realmObjects.count)
                 let idKey = T.entityIdProperty()
-                let objectIds = cache.detach(entities: realmObjects, query: self.query).map {
+                let objectIds = cache.detach(entities: realmObjects, query: self.query).compactMap {
                     $0[idKey] as? String
-                }.filter {
-                    $0 != nil
-                }.map {
-                    $0!
                 }
                 if cache.remove(entities: realmObjects), let sync = self.sync {
-                    for objectId in objectIds {
+                    objectIds.forEachAutoreleasepool { objectId in
                         if objectId.hasPrefix(ObjectIdTmpPrefix) {
                             sync.removeAllPendingOperations(objectId)
                         } else {

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -353,7 +353,7 @@ class KinveyTestCase: XCTestCase {
         super.setUp()
         
         originalLogLevel = Kinvey.logLevel
-        Kinvey.logLevel = .verbose
+        Kinvey.logLevel = .error
         
         if KinveyTestCase.appInitialize == KinveyTestCase.appInitializeDevelopment {
             initializeDevelopment()

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -576,4 +576,17 @@ class KinveyTestCase: XCTestCase {
         return json
     }
     
+    func startLogPolling(timeInterval: TimeInterval = 30, function: String = #function) -> DispatchSourceTimer {
+        let startTime = Date()
+        let timer = DispatchSource.makeTimerSource()
+        timer.schedule(deadline: .now() + timeInterval, repeating: timeInterval)
+        timer.setEventHandler {
+            autoreleasepool {
+                print("Running \(function) for \(Int(round(-startTime.timeIntervalSinceNow)))s")
+            }
+        }
+        timer.resume()
+        return timer
+    }
+    
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -1832,7 +1832,7 @@ class SyncStoreTests: StoreTestCase {
         let timer = startLogPolling()
         let reportMemory1 = reportMemory()!
         
-        let count = 40_000
+        let count = 10_000
         let range = 1 ... count
         let json = range.map { i in
             Person {

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -1829,9 +1829,10 @@ class SyncStoreTests: StoreTestCase {
     }
     
     func testRemoveAllMemoryLeak() {
+        let timer = startLogPolling()
         let reportMemory1 = reportMemory()!
         
-        let count = 50_000
+        let count = 40_000
         let range = 1 ... count
         let json = range.map { i in
             Person {
@@ -1841,6 +1842,7 @@ class SyncStoreTests: StoreTestCase {
         }
         mockResponse(json: json)
         defer {
+            timer.cancel()
             setURLProtocol(nil)
         }
         

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CONFIGURATION?=Release
 VERSION=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${PWD}/Kinvey/Kinvey/Info.plist")
-IPHONE_SE_SIMULATOR_ID=$(shell instruments -s | grep 'iPhone X (11.4)' | awk '{ print substr($$4, 2, 36) }' | head -n 1)
 CURRENT_BRANCH=$(shell git branch | awk '{split($$0, array, " "); if (array[1] == "*") print array[2]}')
 DEVCENTER_GIT=git@github.com:Kinvey/devcenter.git
 DEVCENTER_GIT_TEST=https://git.heroku.com/v3yk1n-devcenter.git
@@ -67,20 +66,10 @@ test: test-ios test-macos
 	
 test-ios:
 	open -a "simulator" --args -CurrentDeviceUDID "$(IPHONE_SE_SIMULATOR_ID)"; \
-	xcodebuild test \
-		-workspace Kinvey.xcworkspace \
-		-scheme Kinvey \
-		-destination "id=$(IPHONE_SE_SIMULATOR_ID)" \
-		-enableCodeCoverage YES \
-		-only-testing:KinveyTests \
-		-only-testing:KinveyAppUITests \
-		-only-testing:PushMissingConfiguration \
-		-only-testing:KinveyTests\ Encrypted \
-		-only-testing:KinveyTests\ Forgot\ To\ Call\ Super \
-		-only-testing:KinveyTests\ Migration\ Database\ Step\ 2
+	xcodebuild -workspace Kinvey.xcworkspace -scheme Kinvey -destination "OS=11.4,name=iPhone X" test -enableCodeCoverage YES
 
 test-macos:
-	xcodebuild -workspace Kinvey.xcworkspace -scheme Kinvey-macOS -enableCodeCoverage YES test
+	xcodebuild -workspace Kinvey.xcworkspace -scheme Kinvey-macOS test -enableCodeCoverage YES
 
 pack:
 	mkdir -p build/Kinvey-$(VERSION)


### PR DESCRIPTION
#### Description

Memory leak detected inside `DataStore.removeAll()`

#### Changes

- Making sure `for` loops are using `autoreleasepool` specially when many items are changed in the cache store

#### Tests

- Unit test that estimate a memory consumption
