### PR TITLE
MLIBZ-2583: better support for cascade deletes

### DIFF
--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -313,7 +313,12 @@ class KinveyTestCase: XCTestCase {
     var encrypted = false
     var useMockData = appKey == nil || appSecret == nil
     
-    static let defaultTimeout: TimeInterval = 60
+    static let defaultTimeout: TimeInterval = {
+        guard let timeout = ProcessInfo.processInfo.environment["TIMEOUT"], let timeInterval = TimeInterval(timeout) else {
+            return 60
+        }
+        return timeInterval
+    }()
     let defaultTimeout: TimeInterval = KinveyTestCase.defaultTimeout
     
     static let appKey = ProcessInfo.processInfo.environment["KINVEY_APP_KEY"]

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -782,18 +782,17 @@ class SyncStoreTests: StoreTestCase {
     }
     
     func testSync() {
-        save()
+        var person = save()
         
         XCTAssertEqual(store.syncCount(), 1)
+        let realm = (store.cache!.cache as! RealmCache<Person>).realm
         
+        var personMockJson = [JsonDictionary]()
         if useMockData {
-            var count = 0
-            var personMockJson: JsonDictionary? = nil
             mockResponse { (request) -> HttpResponse in
-                defer { count += 1 }
-                switch count {
-                case 0:
-                    XCTAssertEqual(request.httpMethod, "POST")
+                let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+                switch (request.httpMethod!, urlComponents.path) {
+                case ("POST", "/appdata/_kid_/Person"):
                     var json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
                     json[Entity.EntityCodingKeys.entityId] = UUID().uuidString
                     json[Entity.EntityCodingKeys.acl] = [
@@ -803,14 +802,21 @@ class SyncStoreTests: StoreTestCase {
                         Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
                         Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
                     ]
-                    personMockJson = json
+                    personMockJson.append(json)
                     return HttpResponse(statusCode: 201, json: json)
-                case 1:
-                    XCTAssertEqual(request.httpMethod, "GET")
+                case ("GET", "/appdata/_kid_/Person"), ("GET", "/appdata/_kid_/Person/"):
                     XCTAssertNotNil(personMockJson)
-                    return HttpResponse(statusCode: 200, json: [personMockJson!])
+                    return HttpResponse(statusCode: 200, json: personMockJson)
+                case ("DELETE", "/appdata/_kid_/Person/\(person.entityId!)"):
+                    if let idx = personMockJson.index(where: { $0[Entity.EntityCodingKeys.entityId] as? String == person.entityId }) {
+                        personMockJson.remove(at: idx)
+                        return HttpResponse(statusCode: 200, json: ["count" : 1])
+                    }
+                    fallthrough
                 default:
-                    Swift.fatalError()
+                    XCTFail("HTTP Method: \(request.httpMethod!)")
+                    XCTFail("URL Path: \(urlComponents.path)")
+                    return HttpResponse(statusCode: 404, data: Data())
                 }
             }
         }
@@ -818,26 +824,106 @@ class SyncStoreTests: StoreTestCase {
             if useMockData { setURLProtocol(nil) }
         }
         
-        weak var expectationSync = expectation(description: "Sync")
-        
-        store.sync() { count, results, error in
-            self.assertThread()
-            XCTAssertNotNil(count)
-            XCTAssertNotNil(results)
-            XCTAssertNil(error)
+        do {
+            weak var expectationSync = expectation(description: "Sync")
             
-            if let count = count {
-                XCTAssertEqual(Int(count), 1)
+            store.sync() { count, results, error in
+                self.assertThread()
+                XCTAssertNotNil(count)
+                XCTAssertNotNil(results)
+                XCTAssertNil(error)
+                
+                if let count = count {
+                    XCTAssertEqual(count, 1)
+                }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 1)
+                
+                expectationSync?.fulfill()
             }
             
-            expectationSync?.fulfill()
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationSync = nil
+            }
+            
+            XCTAssertEqual(store.syncCount(), 0)
         }
         
-        waitForExpectations(timeout: defaultTimeout) { error in
-            expectationSync = nil
+        do {
+            weak var expectationFind = expectation(description: "Find")
+            
+            store.find() {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 1)
+                    if let _person = persons.first {
+                        person = _person
+                    }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 1)
+                
+                expectationFind?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationFind = nil
+            }
+            
+            XCTAssertEqual(store.syncCount(), 0)
         }
-
-        XCTAssertEqual(store.syncCount(), 0)
+        
+        do {
+            weak var expectationRemove = expectation(description: "Remove")
+            
+            try store.remove(person) {
+                switch $0 {
+                case .success(let count):
+                    XCTAssertEqual(count, 1)
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 0)
+                
+                expectationRemove?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationRemove = nil
+            }
+            
+            XCTAssertEqual(store.syncCount(), 1)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        
+        do {
+            weak var expectationSync = expectation(description: "Sync")
+            
+            store.sync() { count, results, error in
+                self.assertThread()
+                XCTAssertNotNil(count)
+                XCTAssertNotNil(results)
+                XCTAssertNil(error)
+                
+                if let count = count {
+                    XCTAssertEqual(count, 1)
+                }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 0)
+                
+                expectationSync?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationSync = nil
+            }
+            
+            XCTAssertEqual(store.syncCount(), 0)
+        }
     }
     
     func testSyncPullTimeoutError() {
@@ -1248,6 +1334,7 @@ class SyncStoreTests: StoreTestCase {
         ]
         
         store.clearCache(query: Query())
+        let realm = (store.cache!.cache as! RealmCache<Person>).realm
         
         do {
             weak var expectationPull = expectation(description: "Pull")
@@ -1263,6 +1350,8 @@ class SyncStoreTests: StoreTestCase {
                     let cacheCount = Int((self.store.cache?.count(query: nil))!)
                     XCTAssertEqual(cacheCount, results.count)
                 }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 3)
                 
                 expectationPull?.fulfill()
             }
@@ -1294,6 +1383,8 @@ class SyncStoreTests: StoreTestCase {
                         XCTAssertEqual(person.personId, "Victor")
                     }
                 }
+                
+                XCTAssertEqual(realm.objects(Metadata.self).count, 1)
                 
                 expectationPull?.fulfill()
             }
@@ -3434,6 +3525,7 @@ class SyncStoreTests: StoreTestCase {
     
     func testServerSideDeltaSetSyncClearCacheNoQuery() {
         let store = try! DataStore<Person>.collection(.sync, options: try! Options(deltaSet: true))
+        let realm = (store.cache!.cache as! RealmCache<Person>).realm
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3487,6 +3579,8 @@ class SyncStoreTests: StoreTestCase {
                 expectationSync = nil
             }
         }
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 1)
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3563,7 +3657,11 @@ class SyncStoreTests: StoreTestCase {
             }
         }
         
+        XCTAssertEqual(realm.objects(Metadata.self).count, 2)
+        
         store.clearCache()
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 0)
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3629,10 +3727,13 @@ class SyncStoreTests: StoreTestCase {
                 expectationSync = nil
             }
         }
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 2)
     }
     
     func testServerSideDeltaSetSyncClearCache() {
         let store = try! DataStore<Person>.collection(.sync, options: try! Options(deltaSet: true))
+        let realm = (store.cache!.cache as! RealmCache<Person>).realm
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3686,6 +3787,8 @@ class SyncStoreTests: StoreTestCase {
                 expectationSync = nil
             }
         }
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 1)
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3761,6 +3864,8 @@ class SyncStoreTests: StoreTestCase {
                 expectationSync = nil
             }
         }
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 2)
         
         let query = Query(format: "name == %@", "Victor")
         store.clearCache(query: query)
@@ -3829,6 +3934,8 @@ class SyncStoreTests: StoreTestCase {
                 expectationSync = nil
             }
         }
+        
+        XCTAssertEqual(realm.objects(Metadata.self).count, 2)
     }
     
     func testServerSideDeltaSetSyncResultSetExceed() {


### PR DESCRIPTION
#### Description

Better support for cascade deletes. In some cases the cascade delete `Acl` and `Metadata` were not working.

#### Changes

- `RealmCache` now covering updates.

#### Tests

- Small additions to existing unit test
