### PR TITLE
MLIBZ-2636: replacing Realm ThreadSafeReference usage

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -459,11 +459,7 @@ open class Client: Credential {
     @discardableResult
     public func ping(completionHandler: @escaping (Result<EnvironmentInfo, Swift.Error>) -> Void) -> AnyRequest<Result<EnvironmentInfo, Swift.Error>> {
         guard let _ = appKey, let _ = appSecret else {
-            let result: Result<EnvironmentInfo, Swift.Error> = .failure(Error.invalidOperation(description: "Please initialize your client calling the initialize() method before call ping()"))
-            DispatchQueue.main.async {
-                completionHandler(result)
-            }
-            return AnyRequest(result)
+            return errorRequest(error: Error.invalidOperation(description: "Please initialize your client calling the initialize() method before call ping()"), completionHandler: completionHandler)
         }
         let request = networkRequestFactory.buildAppDataPing(
             options: options,

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -185,9 +185,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         do {
             try validate(id: id)
         } catch {
-            let result: Result<T, Swift.Error> = .failure(error)
-            completionHandler?(result)
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
         
         let readPolicy = options?.readPolicy ?? self.readPolicy
@@ -237,9 +235,7 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
             return request
         } catch {
-            let result: Result<AnyRandomAccessCollection<T>, Swift.Error> = .failure(error)
-            completionHandler?(result)
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
     }
     
@@ -738,9 +734,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         do {
             try validate(id: id)
         } catch {
-            let result: Result<Int, Swift.Error> = .failure(error)
-            completionHandler?(result)
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
 
         let writePolicy = options?.writePolicy ?? self.writePolicy
@@ -769,11 +763,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         completionHandler: ((Result<Int, Swift.Error>) -> Void)?
     ) -> AnyRequest<Result<Int, Swift.Error>> {
         guard !ids.isEmpty else {
-            let result: Result<Int, Swift.Error> = .failure(Error.invalidOperation(description: "ids cannot be an empty array"))
-            DispatchQueue.main.async {
-                completionHandler?(result)
-            }
-            return AnyRequest(result)
+            return errorRequest(error: Error.invalidOperation(description: "ids cannot be an empty array"), completionHandler: completionHandler)
         }
         
         let query = Query(format: "\(try! T.entityIdProperty()) IN %@", ids as AnyObject)

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -54,7 +54,17 @@ open class DataStore<T: Persistable> where T: NSObject {
     internal let cache: AnyCache<T>?
     internal let sync: AnySync?
     
-    open fileprivate(set) var deltaSet: Bool
+    @available(*, deprecated: 3.18.2, message: "Please use DataStore.options instead")
+    open fileprivate(set) var deltaSet: Bool {
+        get {
+            return options?.deltaSet ?? false
+        }
+        set {
+            options = try! Options(self.options, deltaSet: true)
+        }
+    }
+    
+    open var options: Options?
     
     fileprivate let uuid = UUID()
     
@@ -90,19 +100,18 @@ open class DataStore<T: Persistable> where T: NSObject {
         options: Options? = nil
     ) throws -> DataStore {
         let client = options?.client ?? sharedClient
-        let deltaSet = options?.deltaSet ?? false
         if !client.isInitialized() {
             throw Error.invalidOperation(description: "Client is not initialized. Call Kinvey.sharedClient.initialize(...) to initialize the client before creating a DataStore.")
         }
         let fileURL = client.fileURL(tag)
         let dataStore = try DataStore<T>(
             type: type,
-            deltaSet: deltaSet,
             autoPagination: autoPagination,
             client: client,
             fileURL: fileURL,
             encryptionKey: client.encryptionKey,
-            validationStrategy: validationStrategy
+            validationStrategy: validationStrategy,
+            options: options
         )
         return dataStore
     }
@@ -118,26 +127,25 @@ open class DataStore<T: Persistable> where T: NSObject {
     ) throws -> DataStore<NewType> where NewType: NSObject {
         return try DataStore<NewType>(
             type: type,
-            deltaSet: deltaSet,
             autoPagination: autoPagination,
             client: client,
             fileURL: fileURL,
             encryptionKey: client.encryptionKey,
-            validationStrategy: validationStrategy
+            validationStrategy: validationStrategy,
+            options: options
         )
     }
     
     fileprivate init(
         type: StoreType,
-        deltaSet: Bool,
         autoPagination: Bool,
         client: Client,
         fileURL: URL?,
         encryptionKey: Data?,
-        validationStrategy: ValidationStrategy?
+        validationStrategy: ValidationStrategy?,
+        options: Options?
     ) throws {
         self.type = type
-        self.deltaSet = deltaSet
         self.autoPagination = autoPagination
         self.client = client
         self.fileURL = fileURL
@@ -152,6 +160,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         readPolicy = type.readPolicy
         writePolicy = type.writePolicy
         self.validationStrategy = validationStrategy
+        self.options = options
     }
     
     private func validate(id: String) throws {
@@ -213,21 +222,25 @@ open class DataStore<T: Persistable> where T: NSObject {
         options: Options? = nil,
         completionHandler: ((Result<AnyRandomAccessCollection<T>, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<AnyRandomAccessCollection<T>, Swift.Error>> {
-        let readPolicy = options?.readPolicy ?? self.readPolicy
-        let deltaSet = options?.deltaSet ?? self.deltaSet
-        let operation = FindOperation<T>(
-            query: Query(query: query, persistableType: T.self),
-            deltaSet: deltaSet,
-            autoPagination: autoPagination,
-            readPolicy: readPolicy,
-            validationStrategy: validationStrategy,
-            cache: cache,
-            options: options
-        )
-        let request = operation.execute { result in
+        do {
+            let readPolicy = options?.readPolicy ?? self.readPolicy
+            let operation = FindOperation<T>(
+                query: Query(query: query, persistableType: T.self),
+                autoPagination: autoPagination,
+                readPolicy: readPolicy,
+                validationStrategy: validationStrategy,
+                cache: cache,
+                options: try Options(specific: options, general: self.options)
+            )
+            let request = operation.execute { result in
+                completionHandler?(result)
+            }
+            return request
+        } catch {
+            let result: Result<AnyRandomAccessCollection<T>, Swift.Error> = .failure(error)
             completionHandler?(result)
+            return AnyRequest(result)
         }
-        return request
     }
     
     /**
@@ -907,33 +920,35 @@ open class DataStore<T: Persistable> where T: NSObject {
     ) -> AnyRequest<Result<AnyRandomAccessCollection<T>, Swift.Error>> {
         var request: AnyRequest<Result<AnyRandomAccessCollection<T>, Swift.Error>>!
         Promise<AnyRandomAccessCollection<T>> { resolver in
-            if type == .network {
+            guard type != .network else {
                 let error = Error.invalidDataStoreType
                 request = AnyRequest(.failure(error))
                 resolver.reject(error)
-            } else if self.syncCount() > 0 {
+                return
+            }
+            
+            guard self.syncCount() == 0 else {
                 let error = Error.invalidOperation(description: "You must push all pending sync items before new data is pulled. Call push() on the data store instance to push pending items, or purge() to remove them.")
                 request = AnyRequest(.failure(error))
                 resolver.reject(error)
-            } else {
-                let deltaSet = options?.deltaSet ?? self.deltaSet
-                let operation = PullOperation<T>(
-                    query: Query(query: query, persistableType: T.self),
-                    deltaSet: deltaSet,
-                    deltaSetCompletionHandler: deltaSetCompletionHandler,
-                    autoPagination: autoPagination,
-                    readPolicy: .forceNetwork,
-                    validationStrategy: validationStrategy,
-                    cache: cache,
-                    options: options
-                )
-                request = operation.execute { result in
-                    switch result {
-                    case .success(let array):
-                        resolver.fulfill(array)
-                    case .failure(let error):
-                        resolver.reject(error)
-                    }
+                return
+            }
+            
+            let operation = PullOperation<T>(
+                query: Query(query: query, persistableType: T.self),
+                deltaSetCompletionHandler: deltaSetCompletionHandler,
+                autoPagination: autoPagination,
+                readPolicy: .forceNetwork,
+                validationStrategy: validationStrategy,
+                cache: cache,
+                options: try Options(specific: options, general: self.options)
+            )
+            request = operation.execute { result in
+                switch result {
+                case .success(let array):
+                    resolver.fulfill(array)
+                case .failure(let error):
+                    resolver.reject(error)
                 }
             }
         }.done { array in

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -79,7 +79,7 @@ open class Entity: Object, Persistable {
     public dynamic var acl: Acl?
     
     internal var realmConfiguration: Realm.Configuration?
-    internal var reference: ThreadSafeReference<Entity>?
+    internal var entityIdReference: String?
     
     /// Default Constructor.
     public required init() {
@@ -131,7 +131,7 @@ open class Entity: Object, Persistable {
      :nodoc:
      */
     open override class func ignoredProperties() -> [String] {
-        var properties = [String]()
+        var properties = [String](arrayLiteral: "entityIdReference")
         for (propertyName, (type, subType)) in ObjCRuntime.properties(forClass: self) {
             if let type = type,
                 let typeClass = NSClassFromString(type),

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -972,9 +972,7 @@ open class FileStore<FileType: File> {
         do {
             try crashIfInvalid(file: file)
         } catch {
-            let result: Result<(FileType, URL), Swift.Error> = .failure(error)
-            completionHandler?(result)
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
         
         if storeType == .sync || storeType == .cache,
@@ -1093,9 +1091,7 @@ open class FileStore<FileType: File> {
         do {
             try crashIfInvalid(file: file)
         } catch {
-            let result: Result<(FileType, Data), Swift.Error> = .failure(error)
-            completionHandler?(result)
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
         
         let multiRequest = MultiRequest<Result<(FileType, Data), Swift.Error>>()

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -341,3 +341,13 @@ func whileAutoreleasepool(_ condition: @autoclosure () -> Bool, _ block: () thro
         }
     }
 }
+
+func errorRequest<S>(error: Swift.Error, completionHandler: ((Result<S, Swift.Error>) -> Void)? = nil) -> AnyRequest<Result<S, Swift.Error>> {
+    let result: Result<S, Swift.Error> = .failure(error)
+    if let completionHandler = completionHandler {
+        DispatchQueue.main.async {
+            completionHandler(result)
+        }
+    }
+    return AnyRequest(result)
+}

--- a/Kinvey/Kinvey/Operation.swift
+++ b/Kinvey/Kinvey/Operation.swift
@@ -107,7 +107,7 @@ class CollectionBlockOperation: BlockOperation {
 internal class Operation<T: Persistable>: NSObject where T: NSObject {
     
     let cache: AnyCache<T>?
-    let options: Options?
+    var options: Options?
     let client: Client
     
     init(

--- a/Kinvey/Kinvey/Options.swift
+++ b/Kinvey/Kinvey/Options.swift
@@ -68,17 +68,32 @@ public struct Options {
         customRequestProperties: [String : Any]? = nil,
         maxSizePerResultSet: Int? = nil
     ) throws {
-        self.client = client
-        self.urlSession = urlSession
-        self.authServiceId = authServiceId
-        self.ttl = ttl
-        self.deltaSet = deltaSet
-        self.readPolicy = readPolicy
-        self.writePolicy = writePolicy
-        self.timeout = timeout
-        self.clientAppVersion = clientAppVersion
-        self.customRequestProperties = customRequestProperties
+        self.client = client ?? options?.client
+        self.urlSession = urlSession ?? options?.urlSession
+        self.authServiceId = authServiceId ?? options?.authServiceId
+        self.ttl = ttl ?? options?.ttl
+        self.deltaSet = deltaSet ?? options?.deltaSet
+        self.readPolicy = readPolicy ?? options?.readPolicy
+        self.writePolicy = writePolicy ?? options?.writePolicy
+        self.timeout = timeout ?? options?.timeout
+        self.clientAppVersion = clientAppVersion ?? options?.clientAppVersion
+        self.customRequestProperties = customRequestProperties ?? options?.customRequestProperties
         self.maxSizePerResultSet = maxSizePerResultSet ?? options?.maxSizePerResultSet
+        try validate(maxSizePerResultSet: self.maxSizePerResultSet)
+    }
+    
+    init(specific: Options?, general: Options?) throws {
+        self.client = specific?.client ?? general?.client
+        self.urlSession = specific?.urlSession ?? general?.urlSession
+        self.authServiceId = specific?.authServiceId ?? general?.authServiceId
+        self.ttl = specific?.ttl ?? general?.ttl
+        self.deltaSet = specific?.deltaSet ?? general?.deltaSet
+        self.readPolicy = specific?.readPolicy ?? general?.readPolicy
+        self.writePolicy = specific?.writePolicy ?? general?.writePolicy
+        self.timeout = specific?.timeout ?? general?.timeout
+        self.clientAppVersion = specific?.clientAppVersion ?? general?.clientAppVersion
+        self.customRequestProperties = specific?.customRequestProperties ?? general?.customRequestProperties
+        self.maxSizePerResultSet = specific?.maxSizePerResultSet ?? general?.maxSizePerResultSet
         try validate(maxSizePerResultSet: self.maxSizePerResultSet)
     }
     

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -46,11 +46,14 @@ extension Persistable where Self: Entity {
                 block(.error(error))
             }
         }
-        guard let realmConfiguration = realmConfiguration, let reference = reference else {
+        guard let realmConfiguration = realmConfiguration,
+            let entityIdReference = entityIdReference,
+            let realm = try? Realm(configuration: realmConfiguration),
+            let entity = realm.object(ofType: Self.self, forPrimaryKey: entityIdReference)
+        else {
             return nil
         }
-        let realm = try! Realm(configuration: realmConfiguration)
-        return AnyNotificationToken(realm.resolve(reference)!.observe(completionHandler))
+        return AnyNotificationToken(entity.observe(completionHandler))
     }
     
 }

--- a/Kinvey/Kinvey/PullOperation.swift
+++ b/Kinvey/Kinvey/PullOperation.swift
@@ -12,7 +12,6 @@ internal class PullOperation<T: Persistable>: FindOperation<T> where T: NSObject
     
     override init(
         query: Query,
-        deltaSet: Bool,
         deltaSetCompletionHandler: ((AnyRandomAccessCollection<T>, AnyRandomAccessCollection<T>) -> Void)?,
         autoPagination: Bool,
         readPolicy: ReadPolicy,
@@ -25,7 +24,6 @@ internal class PullOperation<T: Persistable>: FindOperation<T> where T: NSObject
     ) {
         super.init(
             query: query,
-            deltaSet: deltaSet,
             deltaSetCompletionHandler: deltaSetCompletionHandler,
             autoPagination: autoPagination,
             readPolicy: readPolicy,

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -64,7 +64,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
         var results: [PendingOperationType]?
         executor.executeAndWait {
             results = self.realm.objects(RealmPendingOperation.self).filter("collectionName == %@", self.collectionName).map {
-                return RealmPendingOperationThreadSafeReference($0)
+                return RealmPendingOperationReference($0)
             }
         }
         return AnyCollection(results!)
@@ -74,7 +74,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
         log.verbose("Removing pending operation: \(pendingOperation)")
         executor.executeAndWait {
             try! self.realm.write {
-                let realmPendingOperation = (pendingOperation as! RealmPendingOperationThreadSafeReference).realmPendingOperation
+                let realmPendingOperation = (pendingOperation as! RealmPendingOperationReference).realmPendingOperation
                 self.realm.delete(realmPendingOperation)
             }
         }

--- a/Kinvey/Kinvey/Request.swift
+++ b/Kinvey/Kinvey/Request.swift
@@ -60,9 +60,9 @@ extension Request {
     
 }
 
-public class AnyRequest<Result>: NSObject, Request {
+public class AnyRequest<T>: NSObject, Request {
     
-    public typealias ResultType = Result
+    public typealias ResultType = T
     
     private let _getExecuting: () -> Bool
     
@@ -82,9 +82,9 @@ public class AnyRequest<Result>: NSObject, Request {
         _cancel()
     }
     
-    private let _getResult: () -> Result?
+    private let _getResult: () -> T?
     
-    public var result: Result? {
+    public var result: T? {
         return _getResult()
     }
     
@@ -94,7 +94,7 @@ public class AnyRequest<Result>: NSObject, Request {
         return _getProgress()
     }
     
-    init<RequestType: Request>(_ request: RequestType, conversionHandler: @escaping (RequestType.ResultType?) -> Result?) {
+    init<RequestType: Request>(_ request: RequestType, conversionHandler: @escaping (RequestType.ResultType?) -> T?) {
         _getExecuting = { request.executing }
         _getCancelled = { request.cancelled }
         _cancel = request.cancel
@@ -102,7 +102,7 @@ public class AnyRequest<Result>: NSObject, Request {
         _getProgress = { request.progress }
     }
     
-    init<RequestType: Request>(_ request: RequestType) where Result == Any {
+    init<RequestType: Request>(_ request: RequestType) where T == Any {
         _getExecuting = { request.executing }
         _getCancelled = { request.cancelled }
         _cancel = request.cancel
@@ -110,7 +110,7 @@ public class AnyRequest<Result>: NSObject, Request {
         _getProgress = { request.progress }
     }
     
-    init<RequestType: Request>(_ request: RequestType) where RequestType.ResultType == Result {
+    init<RequestType: Request>(_ request: RequestType) where RequestType.ResultType == T {
         _getExecuting = { request.executing }
         _getCancelled = { request.cancelled }
         _cancel = request.cancel

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -184,11 +184,7 @@ open class User: NSObject, Credential {
         do {
             try client.validate()
         } catch {
-            let result: Result<U, Swift.Error> = .failure(error)
-            DispatchQueue.main.async {
-                completionHandler?(result)
-            }
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
 
         let request = client.networkRequestFactory.buildUserSignUp(
@@ -339,11 +335,7 @@ open class User: NSObject, Credential {
         do {
             try client.validate()
         } catch {
-            let result: Result<U, Swift.Error> = .failure(error)
-            DispatchQueue.main.async {
-                completionHandler?(result)
-            }
-            return AnyRequest(result)
+            return errorRequest(error: error, completionHandler: completionHandler)
         }
         
         let requests = MultiRequest<Result<U, Swift.Error>>()
@@ -505,11 +497,7 @@ open class User: NSObject, Credential {
         completionHandler: ((Result<Void, Swift.Error>) -> Void)? = nil
     ) -> AnyRequest<Result<Void, Swift.Error>> {
         guard let _ = email else {
-            let result: Result<Void, Swift.Error> = .failure(Error.invalidOperation(description: "Email is required to send the email confirmation"))
-            DispatchQueue.main.async {
-                completionHandler?(result)
-            }
-            return AnyRequest(result)
+            return errorRequest(error: Error.invalidOperation(description: "Email is required to send the email confirmation"), completionHandler: completionHandler)
         }
         
         return User.sendEmailConfirmation(
@@ -574,13 +562,7 @@ open class User: NSObject, Credential {
                 completionHandler: completionHandler
             )
         }
-        let result: Result<Void, Swift.Error> = .failure(Error.userWithoutEmailOrUsername)
-        if let completionHandler = completionHandler {
-            DispatchQueue.main.async(execute: { () -> Void in
-                completionHandler(result)
-            })
-        }
-        return AnyRequest(result)
+        return errorRequest(error: Error.userWithoutEmailOrUsername, completionHandler: completionHandler)
     }
     
     /**
@@ -1280,11 +1262,7 @@ open class User: NSObject, Credential {
             do {
                 try client.validate()
             } catch {
-                let result: Result<U, Swift.Error> = .failure(error)
-                DispatchQueue.main.async {
-                    completionHandler?(result)
-                }
-                return AnyRequest(result)
+                return errorRequest(error: error, completionHandler: completionHandler)
             }
             
             let request = client.networkRequestFactory.buildUserLogin(

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -7210,12 +7210,12 @@ class SyncStoreTests: StoreTestCase {
         person.name = "Victor"
         XCTAssertNil(person.realm)
         XCTAssertNil(person.realmConfiguration)
-        XCTAssertNil(person.reference)
+        XCTAssertNil(person.entityIdReference)
         
         let person2 = try! dataStore.save(person, options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertNil(person2.realm)
         XCTAssertNotNil(person2.realmConfiguration)
-        XCTAssertNotNil(person2.reference)
+        XCTAssertNotNil(person2.entityIdReference)
         
         var notified = false
         
@@ -7295,18 +7295,20 @@ class SyncStoreTests: StoreTestCase {
         person.name = personName
         XCTAssertNil(person.realm)
         XCTAssertNil(person.realmConfiguration)
-        XCTAssertNil(person.reference)
+        XCTAssertNil(person.entityIdReference)
         
         let person2 = try! dataStore.save(person, options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertNil(person2.realm)
         XCTAssertNotNil(person2.realmConfiguration)
-        XCTAssertNotNil(person2.reference)
+        XCTAssertNotNil(person2.entityIdReference)
         
         waitForExpectations(timeout: defaultTimeout) { (error) in
             notificationToken?.invalidate()
             expectationObserveInitial = nil
             expectationObserveUpdate = nil
         }
+        
+        XCTAssertEqual(count, 2)
     }
     
     func testPullWithSkip() {
@@ -7556,6 +7558,148 @@ class SyncStoreTests: StoreTestCase {
         }
         
         do {
+            weak var expectationFind = expectation(description: "Find")
+            
+            store.find() {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 2)
+                    if let person = persons.first {
+                        XCTAssertEqual(person.entityId, id1)
+                        XCTAssertEqual(person.personId, id1)
+                        XCTAssertEqual(person.name, name1)
+                        XCTAssertEqual(person.age, age1)
+                        XCTAssertEqual(person.acl?.creator, creator1)
+                        XCTAssertEqual(person.metadata?.lmt, lmt1)
+                        XCTAssertEqual(person.metadata?.ect, ect1)
+                    }
+                    if let person = persons.last {
+                        XCTAssertEqual(person.entityId, id2)
+                        XCTAssertEqual(person.personId, id2)
+                        XCTAssertEqual(person.name, name2)
+                        XCTAssertEqual(person.age, age2)
+                        XCTAssertEqual(person.acl?.creator, creator2)
+                        XCTAssertEqual(person.metadata?.lmt, lmt2)
+                        XCTAssertEqual(person.metadata?.ect, ect2)
+                    }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+                
+                expectationFind?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout, handler: { (error) in
+                expectationFind = nil
+            })
+        }
+    }
+    
+    func testPullAutoPaginationDeltaSetCodable() {
+        let id1 = UUID().uuidString
+        let name1 = UUID().uuidString
+        let age1 = Int(arc4random())
+        let creator1 = UUID().uuidString
+        let lmt1 = Date().toString()
+        let ect1 = Date().toString()
+        
+        let id2 = UUID().uuidString
+        let name2 = UUID().uuidString
+        let age2 = Int(arc4random())
+        let creator2 = UUID().uuidString
+        let lmt2 = Date().toString()
+        let ect2 = Date().toString()
+        
+        let mockObjs: [[String : Any]] = [
+            [
+                "_id": id1,
+                "name": name1,
+                "age": age1,
+                "_acl": [
+                    "creator": creator1
+                ],
+                "_kmd": [
+                    "lmt": lmt1,
+                    "ect": ect1
+                ]
+            ],
+            [
+                "_id": id2,
+                "name": name2,
+                "age": age2,
+                "_acl": [
+                    "creator": creator2
+                ],
+                "_kmd": [
+                    "lmt": lmt2,
+                    "ect": ect2
+                ]
+            ]
+        ]
+        
+        let maxSizePerResultSet = 1
+        let store = try! DataStore<PersonCodable>.collection(.sync, autoPagination: true, options: try! Options(deltaSet: true, maxSizePerResultSet: maxSizePerResultSet))
+        
+        XCTContext.runActivity(named: "Pull Data") { activity in
+            var count = 0
+            mockResponse { request in
+                let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+                switch urlComponents.path {
+                case "/appdata/\(self.client.appKey!)/\(PersonCodable.collectionName())/_count":
+                    return HttpResponse(json: ["count" : mockObjs.count])
+                case "/appdata/\(self.client.appKey!)/\(PersonCodable.collectionName())/":
+                    let skip = Int(urlComponents.queryItems!.filter({ $0.name == "skip" }).first!.value!)!
+                    XCTAssertEqual(skip, count)
+                    let limit = Int(urlComponents.queryItems!.filter({ $0.name == "limit" }).first!.value!)!
+                    XCTAssertEqual(limit, maxSizePerResultSet)
+                    count += limit
+                    return HttpResponse(json: Array(mockObjs[skip ..< skip + limit]))
+                default:
+                    XCTFail(request.url!.path)
+                    return HttpResponse(statusCode: 404, data: Data())
+                }
+            }
+            defer {
+                setURLProtocol(nil)
+            }
+            
+            weak var expectationPull = expectation(description: "Pull")
+            
+            store.pull() {
+                switch $0 {
+                case .success(let persons):
+                    XCTAssertEqual(persons.count, 2)
+                    if let person = persons.first {
+                        XCTAssertEqual(person.entityId, id1)
+                        XCTAssertEqual(person.personId, id1)
+                        XCTAssertEqual(person.name, name1)
+                        XCTAssertEqual(person.age, age1)
+                        XCTAssertEqual(person.acl?.creator, creator1)
+                        XCTAssertEqual(person.metadata?.lmt, lmt1)
+                        XCTAssertEqual(person.metadata?.ect, ect1)
+                    }
+                    if let person = persons.last {
+                        XCTAssertEqual(person.entityId, id2)
+                        XCTAssertEqual(person.personId, id2)
+                        XCTAssertEqual(person.name, name2)
+                        XCTAssertEqual(person.age, age2)
+                        XCTAssertEqual(person.acl?.creator, creator2)
+                        XCTAssertEqual(person.metadata?.lmt, lmt2)
+                        XCTAssertEqual(person.metadata?.ect, ect2)
+                    }
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+                
+                expectationPull?.fulfill()
+            }
+            
+            waitForExpectations(timeout: defaultTimeout, handler: { (error) in
+                expectationPull = nil
+            })
+        }
+        
+        XCTContext.runActivity(named: "Find Local Data") { activity in
             weak var expectationFind = expectation(description: "Find")
             
             store.find() {


### PR DESCRIPTION
#### Description

Replacing Realm `ThreadSafeReference` usage since it can't be used inside a transaction

#### Changes

- Using the `primaryKey` as a reference instead of a `ThreadSafeReference` instance

#### Tests

- Unit test added to cover the use case
