### PR TITLE
MLIBZ-2646: support for list of primitive values for Codable

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -268,8 +268,51 @@ let mappingOperationQueue: OperationQueue = {
 var kinveyProperyMapping = [String : PropertyMap]()
 var currentMappingClass: String?
 
+public protocol PrimitiveValue: Hashable, Decodable {}
+extension String: PrimitiveValue {}
+extension Int: PrimitiveValue {}
+extension Float: PrimitiveValue {}
+extension Double: PrimitiveValue {}
+extension Bool: PrimitiveValue {}
+
+public protocol ListSupportedValue: Hashable {
+    
+    associatedtype Value: PrimitiveValue
+    
+    var value: Value { get set }
+    
+    init(_ value: Value)
+    
+}
+
+extension ListSupportedValue {
+    
+    fileprivate func isEqual(_ this: Self, _ object: Any?) -> Bool {
+        switch object {
+        case let other as Self: return this.value == other.value
+        case let value as Self.Value: return this.value == value
+        default: return false
+        }
+    }
+    
+}
+
+fileprivate func decode<T>(from decoder: Decoder) throws -> T where T: Decodable {
+    let container = try decoder.singleValueContainer()
+    return try container.decode(T.self)
+}
+
+extension ListSupportedValue {
+    
+    fileprivate func encode<T>(_ value: T, to encoder: Encoder) throws where T: Encodable {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+    
+}
+
 /// Wrapper type for string values that needs to be stored locally in the device
-final public class StringValue: Object, ExpressibleByStringLiteral {
+final public class StringValue: Object, ExpressibleByStringLiteral, ListSupportedValue {
     
     /// String value for the wrapper
     @objc
@@ -315,15 +358,8 @@ extension StringValue /* Hashable */ {
 
 extension StringValue /* Equatable */ {
     
-    public static func == (lhs: StringValue, rhs: StringValue) -> Bool {
-        return lhs.value == rhs.value
-    }
-    
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? StringValue else {
-            return false
-        }
-        return self == other
+        return isEqual(self, object)
     }
     
 }
@@ -331,8 +367,7 @@ extension StringValue /* Equatable */ {
 extension StringValue: Decodable {
     
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(try container.decode(String.self))
+        self.init(try decode(from: decoder))
     }
     
 }
@@ -340,8 +375,7 @@ extension StringValue: Decodable {
 extension StringValue: Encodable {
     
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try encode(value, to: encoder)
     }
     
 }
@@ -349,7 +383,7 @@ extension StringValue: Encodable {
 /**
  Wrapper type for integer values that needs to be stored locally in the device
  */
-final public class IntValue: Object, ExpressibleByIntegerLiteral {
+final public class IntValue: Object, ExpressibleByIntegerLiteral, ListSupportedValue {
     
     /// Integer value for the wrapper
     @objc
@@ -383,15 +417,8 @@ extension IntValue /* Hashable */ {
 
 extension IntValue /* Equatable */ {
     
-    public static func == (lhs: IntValue, rhs: IntValue) -> Bool {
-        return lhs.value == rhs.value
-    }
-    
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? IntValue else {
-            return false
-        }
-        return self == other
+        return isEqual(self, object)
     }
     
 }
@@ -399,8 +426,7 @@ extension IntValue /* Equatable */ {
 extension IntValue: Decodable {
     
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(try container.decode(Int.self))
+        self.init(try decode(from: decoder))
     }
     
 }
@@ -408,8 +434,7 @@ extension IntValue: Decodable {
 extension IntValue: Encodable {
     
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try encode(value, to: encoder)
     }
     
 }
@@ -417,7 +442,7 @@ extension IntValue: Encodable {
 /**
  Wrapper type for float values that needs to be stored locally in the device
  */
-final public class FloatValue: Object, ExpressibleByFloatLiteral {
+final public class FloatValue: Object, ExpressibleByFloatLiteral, ListSupportedValue {
     
     /// Float value for the wrapper
     @objc
@@ -451,15 +476,8 @@ extension FloatValue /* Hashable */ {
 
 extension FloatValue /* Equatable */ {
     
-    public static func == (lhs: FloatValue, rhs: FloatValue) -> Bool {
-        return lhs.value == rhs.value
-    }
-    
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? FloatValue else {
-            return false
-        }
-        return self == other
+        return isEqual(self, object)
     }
     
 }
@@ -467,8 +485,7 @@ extension FloatValue /* Equatable */ {
 extension FloatValue: Decodable {
     
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(try container.decode(Float.self))
+        self.init(try decode(from: decoder))
     }
     
 }
@@ -476,8 +493,7 @@ extension FloatValue: Decodable {
 extension FloatValue: Encodable {
     
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try encode(value, to: encoder)
     }
     
 }
@@ -485,7 +501,7 @@ extension FloatValue: Encodable {
 /**
  Wrapper type for double values that needs to be stored locally in the device
  */
-final public class DoubleValue: Object, ExpressibleByFloatLiteral {
+final public class DoubleValue: Object, ExpressibleByFloatLiteral, ListSupportedValue {
     
     /// Double value for the wrapper
     @objc
@@ -519,15 +535,8 @@ extension DoubleValue /* Hashable */ {
 
 extension DoubleValue /* Equatable */ {
     
-    public static func == (lhs: DoubleValue, rhs: DoubleValue) -> Bool {
-        return lhs.value == rhs.value
-    }
-    
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? DoubleValue else {
-            return false
-        }
-        return self == other
+        return isEqual(self, object)
     }
     
 }
@@ -535,8 +544,7 @@ extension DoubleValue /* Equatable */ {
 extension DoubleValue: Decodable {
     
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(try container.decode(Double.self))
+        self.init(try decode(from: decoder))
     }
     
 }
@@ -544,8 +552,7 @@ extension DoubleValue: Decodable {
 extension DoubleValue: Encodable {
     
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try encode(value, to: encoder)
     }
     
 }
@@ -553,7 +560,7 @@ extension DoubleValue: Encodable {
 /**
  Wrapper type for boolean values that needs to be stored locally in the device
  */
-final public class BoolValue: Object, ExpressibleByBooleanLiteral {
+final public class BoolValue: Object, ExpressibleByBooleanLiteral, ListSupportedValue {
     
     /// Boolean value for the wrapper
     @objc
@@ -587,15 +594,8 @@ extension BoolValue /* Hashable */ {
 
 extension BoolValue /* Equatable */ {
     
-    public static func == (lhs: BoolValue, rhs: BoolValue) -> Bool {
-        return lhs.value == rhs.value
-    }
-    
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? BoolValue else {
-            return false
-        }
-        return self == other
+        return isEqual(self, object)
     }
     
 }
@@ -603,8 +603,7 @@ extension BoolValue /* Equatable */ {
 extension BoolValue: Decodable {
     
     public convenience init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.init(try container.decode(Bool.self))
+        self.init(try decode(from: decoder))
     }
     
 }
@@ -612,8 +611,7 @@ extension BoolValue: Decodable {
 extension BoolValue: Encodable {
     
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try encode(value, to: encoder)
     }
     
 }

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -269,7 +269,7 @@ var kinveyProperyMapping = [String : PropertyMap]()
 var currentMappingClass: String?
 
 /// Wrapper type for string values that needs to be stored locally in the device
-open class StringValue: Object, ExpressibleByStringLiteral {
+final public class StringValue: Object, ExpressibleByStringLiteral {
     
     /// String value for the wrapper
     @objc
@@ -301,10 +301,55 @@ open class StringValue: Object, ExpressibleByStringLiteral {
     
 }
 
+extension StringValue /* Hashable */ {
+    
+    public override var hash: Int {
+        return value.hash
+    }
+    
+    public override var hashValue: Int {
+        return value.hashValue
+    }
+    
+}
+
+extension StringValue /* Equatable */ {
+    
+    public static func == (lhs: StringValue, rhs: StringValue) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? StringValue else {
+            return false
+        }
+        return self == other
+    }
+    
+}
+
+extension StringValue: Decodable {
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(try container.decode(String.self))
+    }
+    
+}
+
+extension StringValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+    
+}
+
 /**
  Wrapper type for integer values that needs to be stored locally in the device
  */
-open class IntValue: Object, ExpressibleByIntegerLiteral {
+final public class IntValue: Object, ExpressibleByIntegerLiteral {
     
     /// Integer value for the wrapper
     @objc
@@ -324,10 +369,55 @@ open class IntValue: Object, ExpressibleByIntegerLiteral {
     
 }
 
+extension IntValue /* Hashable */ {
+    
+    public override var hash: Int {
+        return value.hashValue
+    }
+    
+    public override var hashValue: Int {
+        return value.hashValue
+    }
+    
+}
+
+extension IntValue /* Equatable */ {
+    
+    public static func == (lhs: IntValue, rhs: IntValue) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? IntValue else {
+            return false
+        }
+        return self == other
+    }
+    
+}
+
+extension IntValue: Decodable {
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(try container.decode(Int.self))
+    }
+    
+}
+
+extension IntValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+    
+}
+
 /**
  Wrapper type for float values that needs to be stored locally in the device
  */
-open class FloatValue: Object, ExpressibleByFloatLiteral {
+final public class FloatValue: Object, ExpressibleByFloatLiteral {
     
     /// Float value for the wrapper
     @objc
@@ -347,10 +437,55 @@ open class FloatValue: Object, ExpressibleByFloatLiteral {
     
 }
 
+extension FloatValue /* Hashable */ {
+    
+    public override var hash: Int {
+        return value.hashValue
+    }
+    
+    public override var hashValue: Int {
+        return value.hashValue
+    }
+    
+}
+
+extension FloatValue /* Equatable */ {
+    
+    public static func == (lhs: FloatValue, rhs: FloatValue) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? FloatValue else {
+            return false
+        }
+        return self == other
+    }
+    
+}
+
+extension FloatValue: Decodable {
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(try container.decode(Float.self))
+    }
+    
+}
+
+extension FloatValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+    
+}
+
 /**
  Wrapper type for double values that needs to be stored locally in the device
  */
-open class DoubleValue: Object, ExpressibleByFloatLiteral {
+final public class DoubleValue: Object, ExpressibleByFloatLiteral {
     
     /// Double value for the wrapper
     @objc
@@ -370,10 +505,55 @@ open class DoubleValue: Object, ExpressibleByFloatLiteral {
     
 }
 
+extension DoubleValue /* Hashable */ {
+    
+    public override var hash: Int {
+        return value.hashValue
+    }
+    
+    public override var hashValue: Int {
+        return value.hashValue
+    }
+    
+}
+
+extension DoubleValue /* Equatable */ {
+    
+    public static func == (lhs: DoubleValue, rhs: DoubleValue) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? DoubleValue else {
+            return false
+        }
+        return self == other
+    }
+    
+}
+
+extension DoubleValue: Decodable {
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(try container.decode(Double.self))
+    }
+    
+}
+
+extension DoubleValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+    
+}
+
 /**
  Wrapper type for boolean values that needs to be stored locally in the device
  */
-open class BoolValue: Object, ExpressibleByBooleanLiteral {
+final public class BoolValue: Object, ExpressibleByBooleanLiteral {
     
     /// Boolean value for the wrapper
     @objc
@@ -389,6 +569,51 @@ open class BoolValue: Object, ExpressibleByBooleanLiteral {
     public convenience init(_ value: Bool) {
         self.init()
         self.value = value
+    }
+    
+}
+
+extension BoolValue /* Hashable */ {
+    
+    public override var hash: Int {
+        return value.hashValue
+    }
+    
+    public override var hashValue: Int {
+        return value.hashValue
+    }
+    
+}
+
+extension BoolValue /* Equatable */ {
+    
+    public static func == (lhs: BoolValue, rhs: BoolValue) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? BoolValue else {
+            return false
+        }
+        return self == other
+    }
+    
+}
+
+extension BoolValue: Decodable {
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(try container.decode(Bool.self))
+    }
+    
+}
+
+extension BoolValue: Encodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
     }
     
 }

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -90,6 +90,11 @@ class PersonCodable: Entity, Codable {
     dynamic var address: AddressCodable?
     
     let addresses = List<AddressCodable>()
+    let stringValues = List<StringValue>()
+    let intValues = List<IntValue>()
+    let floatValues = List<FloatValue>()
+    let doubleValues = List<DoubleValue>()
+    let boolValues = List<BoolValue>()
     
     //testing properties that must be ignored
     var personDelegate: PersonDelegate?
@@ -111,6 +116,11 @@ class PersonCodable: Entity, Codable {
         case address
         case addresses
         case geolocation
+        case stringValues
+        case intValues
+        case floatValues
+        case doubleValues
+        case boolValues
         
     }
     
@@ -125,6 +135,26 @@ class PersonCodable: Entity, Codable {
         if let addresses = try container.decodeIfPresent(List<AddressCodable>.self, forKey: .addresses) {
             self.addresses.removeAll()
             self.addresses.append(objectsIn: addresses)
+        }
+        if let stringValues = try container.decodeIfPresent(List<StringValue>.self, forKey: .stringValues) {
+            self.stringValues.removeAll()
+            self.stringValues.append(objectsIn: stringValues)
+        }
+        if let intValues = try container.decodeIfPresent(List<IntValue>.self, forKey: .intValues) {
+            self.intValues.removeAll()
+            self.intValues.append(objectsIn: intValues)
+        }
+        if let floatValues = try container.decodeIfPresent(List<FloatValue>.self, forKey: .floatValues) {
+            self.floatValues.removeAll()
+            self.floatValues.append(objectsIn: floatValues)
+        }
+        if let doubleValues = try container.decodeIfPresent(List<DoubleValue>.self, forKey: .doubleValues) {
+            self.doubleValues.removeAll()
+            self.doubleValues.append(objectsIn: doubleValues)
+        }
+        if let boolValues = try container.decodeIfPresent(List<BoolValue>.self, forKey: .boolValues) {
+            self.boolValues.removeAll()
+            self.boolValues.append(objectsIn: boolValues)
         }
         geolocation = try container.decodeIfPresent(GeoPoint.self, forKey: .geolocation)
     }
@@ -153,6 +183,11 @@ class PersonCodable: Entity, Codable {
         try container.encodeIfPresent(age, forKey: .age)
         try container.encodeIfPresent(address, forKey: .address)
         try container.encodeIfPresent(addresses, forKey: .addresses)
+        try container.encodeIfPresent(stringValues, forKey: .stringValues)
+        try container.encodeIfPresent(intValues, forKey: .intValues)
+        try container.encodeIfPresent(floatValues, forKey: .floatValues)
+        try container.encodeIfPresent(doubleValues, forKey: .doubleValues)
+        try container.encodeIfPresent(boolValues, forKey: .boolValues)
         try container.encodeIfPresent(geolocation, forKey: .geolocation)
         
         try super.encode(to: encoder)
@@ -297,5 +332,112 @@ class AddressCodable: Object, Codable {
     
     @objc
     dynamic var city: String?
+    
+}
+
+class Issue311_MyModel: Kinvey.Entity {
+    
+    @objc dynamic var someSimpleProperty: String?
+    @objc dynamic var someComplexProperty: Issue311_ComplexType?
+    
+    override static func collectionName() -> String {
+        return "MyModel"
+    }
+    
+    override func propertyMapping(_ map: Map) {
+        super.propertyMapping(map)
+        
+        self.someSimpleProperty <- ("someSimpleProperty", map["someSimpleProperty"])
+        self.someComplexProperty <- ("someComplexProperty", map["someComplexProperty"])
+    }
+}
+
+final class Issue311_ComplexType: Kinvey.Object, Kinvey.Mappable {
+    
+    @objc dynamic var someSimpleProperty: String?
+    let someListProperty = Kinvey.List<StringValue>()
+    
+    convenience init?(map: Map) {
+        self.init()
+    }
+    
+    func mapping(map: Map) {
+        self.someSimpleProperty <- ("someSimpleProperty", map["someSimpleProperty"])
+        self.someListProperty <- ("someListProperty", map["someListProperty"])
+    }
+}
+
+class Issue311_MyModelCodable: Kinvey.Entity, Codable {
+    
+    @objc dynamic var someSimpleProperty: String?
+    @objc dynamic var someComplexProperty: Issue311_ComplexTypeCodable?
+    
+    override static func collectionName() -> String {
+        return "MyModel"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+
+        case someSimpleProperty
+        case someComplexProperty
+
+    }
+
+    required init() {
+        super.init()
+    }
+
+    required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+
+    required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+
+    @available(*, deprecated)
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        someSimpleProperty = try container.decodeIfPresent(String.self, forKey: .someSimpleProperty)
+        someComplexProperty = try container.decodeIfPresent(Issue311_ComplexTypeCodable.self, forKey: .someComplexProperty)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+
+        var container = try encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(someSimpleProperty, forKey: .someSimpleProperty)
+        try container.encode(someComplexProperty, forKey: .someComplexProperty)
+    }
+}
+
+final class Issue311_ComplexTypeCodable: Kinvey.Object, Codable {
+    
+    @objc dynamic var someSimpleProperty: String?
+    let someListProperty = Kinvey.List<StringValue>()
+    
+    enum CodingKeys: String, CodingKey {
+        
+        case someSimpleProperty
+        case someListProperty
+        
+    }
+    
+    convenience init(from decoder: Decoder) throws {
+        self.init()
+        
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        someSimpleProperty = try container.decodeIfPresent(String.self, forKey: .someSimpleProperty)
+        if let someListProperty = try container.decodeIfPresent(Kinvey.List<StringValue>.self, forKey: .someListProperty) {
+            self.someListProperty.removeAll()
+            self.someListProperty.append(objectsIn: someListProperty)
+        }
+    }
     
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -7417,7 +7417,11 @@ class SyncStoreTests: StoreTestCase {
             XCTAssertEqual(myModel.someSimpleProperty, "A")
             XCTAssertEqual(myModel.someComplexProperty?.someSimpleProperty, "B")
             XCTAssertEqual(myModel.someComplexProperty?.someListProperty.first, "C")
+            XCTAssertTrue(myModel.someComplexProperty?.someListProperty.first == "C")
+            XCTAssertTrue(myModel.someComplexProperty?.someListProperty.first?.isEqual("C") ?? false)
             XCTAssertEqual(myModel.someComplexProperty?.someListProperty.last, "D")
+            XCTAssertTrue(myModel.someComplexProperty?.someListProperty.last == "D")
+            XCTAssertTrue(myModel.someComplexProperty?.someListProperty.last?.isEqual("D") ?? false)
         } catch {
             XCTFail(error.localizedDescription)
         }


### PR DESCRIPTION
#### Description

Support for `List<T>` of primitive values like `List<StringValue>`, `List<IntValue>`, `List<FloatValue>`, `List<DoubleValue>` and `List<BoolValue>`

#### Changes

- Adding implementation for `Hashable`, `Equatable` and `Codable` for all primitive values

#### Tests

- New unit tests added
