### PR TITLE
Access on User.encode changed to open

### DIFF
--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -925,7 +925,7 @@ open class User: NSObject, Credential {
         super.init()
     }
     
-    public func encode(to encoder: Encoder) throws {
+    open func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(_userId, forKey: .userId)
         try container.encodeIfPresent(acl, forKey: .acl)


### PR DESCRIPTION
Current access on `User.encode` method is `public` which prevents overriding the method and in turn implementing a custom User class that conforms to the `Codable` protocol.

As Kinvey.Entity already has this method and it is `open` this change makes sense.

Related to comment in #311.