### PR TITLE
MLIBZ-2661: bugfix for large pull memory consumption

### DIFF
--- a/Kinvey/Kinvey/Cache.swift
+++ b/Kinvey/Kinvey/Cache.swift
@@ -21,6 +21,8 @@ internal protocol CacheType: class {
     
     func save(entities: AnyRandomAccessCollection<Type>, syncQuery: SyncQuery?)
     
+    func save(syncQuery: SyncQuery)
+    
     func find(byId objectId: String) -> Type?
     
     func find(byQuery query: Query) -> AnyRandomAccessCollection<Type>
@@ -133,6 +135,7 @@ class AnyCache<T: Persistable>: CacheType {
     private let _setTTL: (TimeInterval?) -> Void
     private let _saveEntity: (T) -> Void
     private let _saveEntities: (AnyRandomAccessCollection<Type>, SyncQuery?) -> Void
+    private let _saveSyncQuery: (SyncQuery) -> Void
     private let _findById: (String) -> T?
     private let _findByQuery: (Query) -> AnyRandomAccessCollection<Type>
     private let _findIdsLmtsByQuery: (Query) -> [String : String]
@@ -162,6 +165,7 @@ class AnyCache<T: Persistable>: CacheType {
         _setTTL = { cache.ttl = $0 }
         _saveEntity = cache.save(entity:)
         _saveEntities = cache.save(entities: syncQuery:)
+        _saveSyncQuery = cache.save(syncQuery:)
         _findById = cache.find(byId:)
         _findByQuery = cache.find(byQuery:)
         _findIdsLmtsByQuery = cache.findIdsLmts(byQuery:)
@@ -187,6 +191,10 @@ class AnyCache<T: Persistable>: CacheType {
     
     func save(entities: AnyRandomAccessCollection<Type>, syncQuery: SyncQuery?) {
         _saveEntities(entities, syncQuery)
+    }
+    
+    func save(syncQuery: SyncQuery) {
+        _saveSyncQuery(syncQuery)
     }
     
     func find(byId objectId: String) -> T? {

--- a/Kinvey/Kinvey/CountOperation.swift
+++ b/Kinvey/Kinvey/CountOperation.swift
@@ -13,15 +13,18 @@ class CountOperation<T: Persistable>: ReadOperation<T, Int, Swift.Error>, ReadOp
     let query: Query?
     
     typealias ResultType = Result<Int, Swift.Error>
+    let requestStartHeaderHandler: ((Date) -> Void)?
     
     init(
         query: Query? = nil,
         readPolicy: ReadPolicy,
         validationStrategy: ValidationStrategy?,
         cache: AnyCache<T>?,
-        options: Options?
+        options: Options?,
+        requestStartHeaderHandler: ((Date) -> Void)? = nil
     ) {
         self.query = query
+        self.requestStartHeaderHandler = requestStartHeaderHandler
         super.init(
             readPolicy: readPolicy,
             validationStrategy: validationStrategy,
@@ -54,6 +57,9 @@ class CountOperation<T: Persistable>: ReadOperation<T, Int, Swift.Error>, ReadOp
             resultType: ResultType.self
         )
         request.execute() { data, response, error in
+            if let requestStartHeader = response?.requestStartHeader {
+                self.requestStartHeaderHandler?(requestStartHeader)
+            }
             let result: ResultType
             if let response = response, response.isOK,
                 let data = data,

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -66,6 +66,10 @@ open class Entity: Object, Persistable {
         throw Error.invalidOperation(description: "Method \(#function) must be overridden")
     }
     
+    open class func translate(property: String) throws -> String? {
+        return nil
+    }
+    
     /// The `_id` property mapped in the Kinvey backend.
     @objc
     public dynamic var entityId: String?

--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -234,3 +234,15 @@ public struct MultipleErrors: Swift.Error {
     public let errors: [Swift.Error]
     
 }
+
+extension NSException {
+    
+    public convenience init(error: Swift.Error) {
+        self.init(error: error as NSError)
+    }
+    
+    public convenience init(error: NSError) {
+        self.init(name: NSExceptionName(rawValue: error.domain), reason: error.localizedFailureReason, userInfo: error.userInfo)
+    }
+    
+}

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -21,6 +21,9 @@ public protocol Persistable: JSONCodable {
     /// Provides the collection name to be matched with the backend.
     static func collectionName() throws -> String
     
+    /// Provides property translations for queries
+    static func translate(property: String) throws -> String?
+    
     /// Default Constructor.
     init()
     

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -52,13 +52,6 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
     typealias `Type` = T
     
     let configuration: Realm.Configuration
-    let _realm: Realm
-    var realm: Realm {
-        executor.executeAndWait {
-            self._realm.refresh()
-        }
-        return _realm
-    }
     let objectSchema: ObjectSchema
     let properties: [String : Property]
     let propertyNames: [String]
@@ -91,17 +84,18 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         }
         configuration.encryptionKey = encryptionKey
         configuration.schemaVersion = schemaVersion
-        
+
+        let realm: Realm
         do {
-            _realm = try Realm(configuration: configuration)
+            realm = try Realm(configuration: configuration)
         } catch {
             configuration.deleteRealmIfMigrationNeeded = true
-            _realm = try! Realm(configuration: configuration)
+            realm = try! Realm(configuration: configuration)
         }
         self.configuration = configuration
         
         let className = NSStringFromClass(T.self).components(separatedBy: ".").last!
-        objectSchema = _realm.schema[className]!
+        objectSchema = realm.schema[className]!
         
         var properties = [String : Property]()
         var propertyNames = [String]()
@@ -126,7 +120,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         
         executor = Executor()
         super.init(persistenceId: persistenceId)
-        log.debug("Cache File: \(self.realm.configuration.fileURL!.path)")
+        log.debug("Cache File: \(newRealm.configuration.fileURL!.path)")
     }
     
     func translate(predicate: NSPredicate) -> NSPredicate {
@@ -287,7 +281,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
     }
     
     fileprivate func realmResults(_ query: Query) -> Results<Entity>? {
-        var realmResults = self.realm.objects(self.entityType)
+        var realmResults = newRealm.objects(self.entityType)
         
         if let predicate = query.predicate {
             if let exception = tryBlock({
@@ -334,6 +328,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         
         json = entity.dictionaryWithValues(forKeys: props)
         
+        let realm = newRealm
         json.keys.forEachAutoreleasepool { property in
             let value = json[property]
                 
@@ -402,7 +397,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
                 newEntity = realm.create((type(of: entity) as! Entity.Type), value: entity, update: true)
             }
             if let entity = entity as? Entity {
-                entity.realmConfiguration = self.realm.configuration
+                entity.realmConfiguration = self.newRealm.configuration
                 entity.entityIdReference = (newEntity as NSObject & Persistable).entityId
             }
         }
@@ -416,7 +411,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
             var newEntities = [Entity]()
             newEntities.reserveCapacity(entities.count)
             try! self.write { realm in
-                for entity in entities {
+                entities.forEachAutoreleasepool { entity in
                     if let entityId = entity.entityId, let oldEntity = realm.object(ofType: entityType, forPrimaryKey: entityId) {
                         self.cascadeDelete(realm: realm, entityType: self.entityTypeClassName, entity: oldEntity, deleteItself: false)
                     }
@@ -440,7 +435,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         log.verbose("Finding object by ID: \(objectId)")
         var result: T?
         executor.executeAndWait {
-            result = self.realm.object(ofType: self.entityType, forPrimaryKey: objectId) as? T
+            result = self.newRealm.object(ofType: self.entityType, forPrimaryKey: objectId) as? T
             if result != nil {
                 if let resultObj = result as? Object {
                     result = self.detach(resultObj, props: self.propertyNames) as? T
@@ -601,7 +596,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         log.verbose("Retriving last sync date")
         var lastSync: Date? = nil
         executor.executeAndWait {
-            lastSync = self.lastSync(query: query, realm: self.realm)?.first?.lastSync
+            lastSync = self.lastSync(query: query, realm: self.newRealm)?.first?.lastSync
         }
         return lastSync
     }
@@ -647,7 +642,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         var _error: Swift.Error? = nil
         executor.executeAndWait {
             do {
-                try self.realm.write {
+                try self.newRealm.write {
                     try block()
                 }
             } catch {
@@ -661,7 +656,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
     
     public func beginWrite() {
         executor.executeAndWait {
-            self.realm.beginWrite()
+            self.newRealm.beginWrite()
         }
     }
     
@@ -669,7 +664,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         var _error: Swift.Error? = nil
         executor.executeAndWait {
             do {
-                try self.realm.commitWrite(withoutNotifying: tokens.compactMap({
+                try self.newRealm.commitWrite(withoutNotifying: tokens.compactMap({
                     $0 as? RealmSwift.NotificationToken ?? ($0 as? AnyNotificationToken)?.notificationToken as? RealmSwift.NotificationToken
                 }))
             } catch {
@@ -683,16 +678,16 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
     
     public func cancelWrite() {
         executor.executeAndWait {
-            self.realm.cancelWrite()
+            self.newRealm.cancelWrite()
         }
     }
     
     private func write(_ block: @escaping (Realm) throws -> Void) throws {
-        if realm.isInWriteTransaction {
+        if newRealm.isInWriteTransaction {
             var _error: Swift.Error? = nil
             executor.executeAndWait {
                 do {
-                    try block(self.realm)
+                    try block(self.newRealm)
                 } catch {
                     _error = error
                 }
@@ -876,18 +871,31 @@ extension RealmCache: DynamicCacheType {
         log.debug("Time elapsed: \(CFAbsoluteTimeGetCurrent() - startTime) s")
     }
     
+    func save(syncQuery: CacheType.SyncQuery) {
+        saveQuery(syncQuery: syncQuery, realm: self.newRealm)
+    }
+    
     private func saveQuery(syncQuery: SyncQuery?, realm: Realm) {
         guard let syncQuery = syncQuery else {
             return
         }
         
-        let realmSyncQuery = _QueryCache()
-        realmSyncQuery.collectionName = entityTypeCollectionName
-        realmSyncQuery.query = syncQuery.query.predicateAsString
-        realmSyncQuery.fields = syncQuery.query.fieldsAsString
-        realmSyncQuery.lastSync = syncQuery.lastSync
-        realmSyncQuery.generateKey()
-        realm.add(realmSyncQuery, update: true)
+        let block: (String) -> Void = { entityTypeCollectionName in
+            let realmSyncQuery = _QueryCache()
+            realmSyncQuery.collectionName = entityTypeCollectionName
+            realmSyncQuery.query = syncQuery.query.predicateAsString
+            realmSyncQuery.fields = syncQuery.query.fieldsAsString
+            realmSyncQuery.lastSync = syncQuery.lastSync
+            realmSyncQuery.generateKey()
+            realm.add(realmSyncQuery, update: true)
+        }
+        if realm.isInWriteTransaction {
+            block(entityTypeCollectionName)
+        } else {
+            try! realm.write {
+                block(entityTypeCollectionName)
+            }
+        }
     }
     
 }

--- a/Kinvey/KinveyAppUITests/KinveyAppUITests.swift
+++ b/Kinvey/KinveyAppUITests/KinveyAppUITests.swift
@@ -120,28 +120,25 @@ class KinveyAppUITests: XCTestCase {
         }
         
         let userIdValue = app.staticTexts["User ID Value"]
+        expect(userIdValue.exists).to(beTrue())
         
         XCTContext.runActivity(named: "Tap Login Button") { activity in
             let tokenMonitor = addUIInterruptionMonitor(withDescription: "SFAuthenticationSession") { (alert) -> Bool in
+                expect(userIdValue.exists).to(beTrue())
                 alert.buttons["Continue"].tap()
+                expect(userIdValue.exists).toEventually(beFalse(), timeout: self.defaultTimeout)
                 activity.add(XCTAttachment(screenshot: app.screenshot()))
+                expect(userIdValue.exists).toEventually(beTrue(), timeout: self.defaultTimeout)
                 return true
             }
             defer {
                 removeUIInterruptionMonitor(tokenMonitor)
             }
             
-            app.buttons["Login"].tap()
-            app.tap()
             activity.add(XCTAttachment(screenshot: app.screenshot()))
             
-            expect(expression: {
-                if userIdValue.exists {
-                    app.tap()
-                    activity.add(XCTAttachment(screenshot: app.screenshot()))
-                }
-                return userIdValue.exists
-            }).toEventually(beFalse(), timeout: defaultTimeout, pollInterval: 5)
+            app.buttons["Login"].tap()
+            app.tap()
             
             activity.add(XCTAttachment(screenshot: app.screenshot()))
             
@@ -217,21 +214,19 @@ class KinveyAppUITests: XCTestCase {
             server.stop()
         }
         
+        let userIdValue = app.staticTexts["User ID Value"]
+        
         addUIInterruptionMonitor(withDescription: "WKWebView") { (alert) -> Bool in
+            expect(userIdValue.exists).to(beTrue())
             alert.buttons["Continue"].tap()
+            expect(userIdValue.exists).toEventually(beFalse(), timeout: self.defaultTimeout)
+            expect(userIdValue.exists).toEventually(beTrue(), timeout: self.defaultTimeout)
             return true
         }
         
         app.buttons["Login"].tap()
         app.tap()
         
-        let userIdValue = app.staticTexts["User ID Value"]
-        expect(expression: {
-            if userIdValue.exists {
-                app.tap()
-            }
-            return userIdValue.exists
-        }).toEventually(beFalse(), timeout: defaultTimeout, pollInterval: 1)
         XCTAssertTrue(userIdValue.waitForExistence(timeout: defaultTimeout))
         expect(userIdValue.exists).toEventually(beTrue(), timeout: defaultTimeout)
         expect(userIdValue.label).toEventually(equal(userId), timeout: defaultTimeout)

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -3770,7 +3770,12 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     case 0:
                         switch urlComponents.path {
                         case "/appdata/\(sharedClient.appKey!)/\(Person.collectionName())/_count":
-                            return HttpResponse(json: ["count" : 3])
+                            let requestStartDate = Date()
+                            requestStartDates.append(requestStartDate)
+                            return HttpResponse(
+                                headerFields: ["X-Kinvey-Request-Start" : requestStartDate.toString()],
+                                json: ["count" : 3]
+                            )
                         default:
                             XCTFail(urlComponents.path)
                             return HttpResponse(statusCode: 404, data: Data())
@@ -3821,7 +3826,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             let results = try store.pull(options: Options(maxSizePerResultSet: 1)).waitForResult(timeout: defaultTimeout).value()
             XCTAssertEqual(results.count, count)
             
-            XCTAssertEqual(requestStartDates.count, 3)
+            XCTAssertEqual(requestStartDates.count, 4)
             XCTAssertTrue(store.cache?.cache is RealmCache<Person>)
             XCTAssertNotNil(store.cache?.cache as? RealmCache<Person>)
             if let cache = store.cache?.cache as? RealmCache<Person> {
@@ -4006,9 +4011,10 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockRequestPathSequence.append(urlComponents.path)
                 switch urlComponents.path {
                 case "/appdata/_kid_/Person/_count":
-                    return HttpResponse(json: [
-                        "count" : json.count
-                    ])
+                    return HttpResponse(
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        json: ["count" : json.count]
+                    )
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         statusCode: 403,
@@ -4446,7 +4452,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         XCTAssertTrue(dataStore.cache?.cache is RealmCache<Person>)
         XCTAssertNotNil(dataStore.cache?.cache as? RealmCache<Person>)
         if let realmCache = dataStore.cache?.cache as? RealmCache<Person> {
-            XCTAssertEqual(realmCache.lastSync(query: query1, realm: realmCache.realm)?.first?.fields, "address,name")
+            XCTAssertEqual(realmCache.lastSync(query: query1, realm: realmCache.newRealm)?.first?.fields, "address,name")
         }
         
         do {
@@ -4485,7 +4491,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             XCTAssertNotNil(dataStore.cache?.cache as? RealmCache<Person>)
             if let realmCache = dataStore.cache?.cache as? RealmCache<Person> {
                 do {
-                    let queryCache = realmCache.lastSync(query: Query(), realm: realmCache.realm)?.first
+                    let queryCache = realmCache.lastSync(query: Query(), realm: realmCache.newRealm)?.first
                     XCTAssertNotNil(queryCache)
                     XCTAssertNil(queryCache?.fields)
                     XCTAssertEqual(queryCache?.key, "Person|nil")
@@ -4537,9 +4543,10 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockRequestPathSequence.append(request.url!.path)
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_count":
-                    return HttpResponse(json: [
-                        "count" : json.count
-                    ])
+                    return HttpResponse(
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        json: ["count" : json.count]
+                    )
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         statusCode: 400,
@@ -4686,9 +4693,10 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockRequestPathSequence.append(urlComponents.path)
                 switch urlComponents.path {
                 case "/appdata/_kid_/Person/_count":
-                    return HttpResponse(json: [
-                        "count" : json.count
-                    ])
+                    return HttpResponse(
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        json: ["count" : json.count]
+                    )
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         statusCode: 400,

--- a/Kinvey/KinveyTests/ForgotToCallSuper.swift
+++ b/Kinvey/KinveyTests/ForgotToCallSuper.swift
@@ -46,11 +46,16 @@ class ForgotToCallSuperEntity2: Entity {
 
 class ForgotToCallSuperPersistable: Persistable {
     
+    
     @objc
     dynamic var myProperty: String?
     
     class func collectionName() -> String {
         return "ForgotToCallSuper"
+    }
+    
+    class func translate(property: String) throws -> String? {
+        return nil
     }
     
     required init() {

--- a/Kinvey/KinveyTests/MemoryCache.swift
+++ b/Kinvey/KinveyTests/MemoryCache.swift
@@ -11,6 +11,9 @@ import Foundation
 
 class MemoryCache<T: Persistable>: Cache<T>, CacheType where T: NSObject {
     
+    func save(syncQuery: CacheType.SyncQuery) {
+    }
+    
     typealias `Type` = T
     
     var memory = [String : T]()

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -771,48 +771,6 @@ class NetworkStoreTests: StoreTestCase {
         }
     }
     
-    func testTranslateQueryCodable() {
-        let store = try! DataStore<PersonCodable>.collection(.sync)
-        let id = UUID().uuidString
-        
-        if useMockData {
-            mockResponse { (request) -> HttpResponse in
-                let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
-                XCTAssertEqual(urlComponents.path, "/appdata/\(self.client.appKey!)/Person/")
-                return HttpResponse(json: [
-                    [
-                        "_id" : id,
-                        "age" : 0,
-                    ]
-                ])
-            }
-        }
-        defer {
-            if useMockData {
-                setURLProtocol(nil)
-            }
-        }
-        
-        weak var expectationPull = expectation(description: "Pull")
-        
-        let query = Query(format: "_id == %@", id)
-        
-        store.pull(query) {
-            switch $0 {
-            case .success(let persons):
-                XCTAssertEqual(persons.count, 1)
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
-            
-            expectationPull?.fulfill()
-        }
-        
-        waitForExpectations(timeout: defaultTimeout) { error in
-            expectationPull = nil
-        }
-    }
-    
     func testCountTimeoutError() {
         let store = try! DataStore<Event>.collection(.network)
         

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -187,6 +187,18 @@ class PersonCodable: Entity, Codable {
         return "Person"
     }
     
+    override class func translate(property: String) -> String? {
+        guard let codingKey = CodingKeys(rawValue: property) else {
+            return nil
+        }
+        switch codingKey {
+        case .personId:
+            return "personId"
+        default:
+            return nil
+        }
+    }
+    
     enum CodingKeys: String, CodingKey {
         
         case personId = "_id"

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -193,7 +193,7 @@ class PersonCodable: Entity, Codable {
         }
         switch codingKey {
         case .personId:
-            return "personId"
+            return NSExpression(forKeyPath: \PersonCodable.personId).keyPath
         default:
             return nil
         }

--- a/Kinvey/KinveyTests/RemoveAllMemoryLeakTests.swift
+++ b/Kinvey/KinveyTests/RemoveAllMemoryLeakTests.swift
@@ -117,7 +117,8 @@ class RemoveAllMemoryLeakTests: StoreTestCase {
             }
         }
         
-        XCTAssertLessThan(getMegabytesUsed()! - megabytesUsageAtStart, 50)
+        let diff = getMegabytesUsed()! - megabytesUsageAtStart
+        XCTAssertLessThan(diff, 60)
     }
     
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -8491,4 +8491,46 @@ class SyncStoreTests: StoreTestCase {
         }
     }
     
+    func testTranslateQueryCodable() {
+        let store = try! DataStore<PersonCodable>.collection(.sync)
+        let id = UUID().uuidString
+        
+        if useMockData {
+            mockResponse { (request) -> HttpResponse in
+                let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+                XCTAssertEqual(urlComponents.path, "/appdata/\(self.client.appKey!)/\(PersonCodable.collectionName())/")
+                return HttpResponse(json: [
+                    [
+                        "_id" : id,
+                        "age" : 0,
+                        ]
+                    ])
+            }
+        }
+        defer {
+            if useMockData {
+                setURLProtocol(nil)
+            }
+        }
+        
+        weak var expectationPull = expectation(description: "Pull")
+        
+        let query = Query(format: "_id == %@", id)
+        
+        store.pull(query) {
+            switch $0 {
+            case .success(let persons):
+                XCTAssertEqual(persons.count, 1)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+            
+            expectationPull?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationPull = nil
+        }
+    }
+    
 }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -785,7 +785,7 @@ class SyncStoreTests: StoreTestCase {
         var person = save()
         
         XCTAssertEqual(store.syncCount(), 1)
-        let realm = (store.cache!.cache as! RealmCache<Person>).realm
+        let realm = (store.cache!.cache as! RealmCache<Person>).newRealm
         
         var personMockJson = [JsonDictionary]()
         if useMockData {
@@ -1334,7 +1334,7 @@ class SyncStoreTests: StoreTestCase {
         ]
         
         store.clearCache(query: Query())
-        let realm = (store.cache!.cache as! RealmCache<Person>).realm
+        let realm = (store.cache!.cache as! RealmCache<Person>).newRealm
         
         do {
             weak var expectationPull = expectation(description: "Pull")
@@ -2704,6 +2704,10 @@ class SyncStoreTests: StoreTestCase {
                 return "NotEntityPersistable"
             }
             
+            static func translate(property: String) -> String? {
+                return nil
+            }
+            
             required override init() {
             }
             
@@ -2746,6 +2750,10 @@ class SyncStoreTests: StoreTestCase {
             
             static func collectionName() -> String {
                 return "NotEntityPersistable"
+            }
+            
+            static func translate(property: String) -> String? {
+                return nil
             }
             
             required override init() {
@@ -3525,7 +3533,7 @@ class SyncStoreTests: StoreTestCase {
     
     func testServerSideDeltaSetSyncClearCacheNoQuery() {
         let store = try! DataStore<Person>.collection(.sync, options: try! Options(deltaSet: true))
-        let realm = (store.cache!.cache as! RealmCache<Person>).realm
+        let realm = (store.cache!.cache as! RealmCache<Person>).newRealm
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -3733,7 +3741,7 @@ class SyncStoreTests: StoreTestCase {
     
     func testServerSideDeltaSetSyncClearCache() {
         let store = try! DataStore<Person>.collection(.sync, options: try! Options(deltaSet: true))
-        let realm = (store.cache!.cache as! RealmCache<Person>).realm
+        let realm = (store.cache!.cache as! RealmCache<Person>).newRealm
         
         do {
             mockResponse { (request) -> HttpResponse in
@@ -7983,7 +7991,7 @@ class SyncStoreTests: StoreTestCase {
         }
         
         let store = try! DataStore<PersonCodable>.collection(.sync)
-        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let items = try! store.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(mockObjs.count, items.count)
         XCTAssertEqual(mockObjs.count, store.cache!.count(query: nil))
@@ -8066,7 +8074,7 @@ class SyncStoreTests: StoreTestCase {
         }
         
         let store = try! DataStore<PersonCodable>.collection(.sync)
-        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let items = try! store.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(mockObjs.count, items.count)
         XCTAssertEqual(mockObjs.count, store.cache!.count(query: nil))
@@ -8149,7 +8157,7 @@ class SyncStoreTests: StoreTestCase {
         }
         
         let store = try! DataStore<PersonCodable>.collection(.sync)
-        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let items = try! store.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(mockObjs.count, items.count)
         XCTAssertEqual(mockObjs.count, store.cache!.count(query: nil))
@@ -8233,7 +8241,7 @@ class SyncStoreTests: StoreTestCase {
         }
         
         let store = try! DataStore<PersonCodable>.collection(.sync)
-        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (store.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let items = try! store.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(mockObjs.count, items.count)
         XCTAssertEqual(mockObjs.count, store.cache!.count(query: nil))
@@ -8309,7 +8317,7 @@ class SyncStoreTests: StoreTestCase {
         
         let personStore = try! DataStore<PersonCodable>.collection(.sync)
         let entityWithRefenceStore = try! DataStore<EntityWithRefenceCodable>.collection(.sync)
-        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let persons = try! personStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         let entities = try! entityWithRefenceStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(1, persons.count)
@@ -8386,7 +8394,7 @@ class SyncStoreTests: StoreTestCase {
         
         let personStore = try! DataStore<PersonCodable>.collection(.sync)
         let entityWithRefenceStore = try! DataStore<EntityWithRefenceCodable>.collection(.sync)
-        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let persons = try! personStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         let entities = try! entityWithRefenceStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(1, persons.count)
@@ -8463,7 +8471,7 @@ class SyncStoreTests: StoreTestCase {
         
         let personStore = try! DataStore<PersonCodable>.collection(.sync)
         let entityWithRefenceStore = try! DataStore<EntityWithRefenceCodable>.collection(.sync)
-        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).realm
+        let realm = (personStore.cache!.cache as! RealmCache<PersonCodable>).newRealm
         let persons = try! personStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         let entities = try! entityWithRefenceStore.pull(options: nil).waitForResult(timeout: defaultTimeout).value()
         XCTAssertEqual(1, persons.count)


### PR DESCRIPTION
#### Description

Realm have a limitation of keeping all objects in memory during a single large transaction. To avoid this situation we did a few changes around the cache layer.

#### Changes

- Request Start persisted is now from the `count()` 

#### Tests

- A few unit tests to ensure the cache data still consistent
