### PR TITLE
Codable for EmailVerification and PasswordReset metadata objects

### DIFF
--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -130,9 +130,9 @@ public class Metadata: Object, Codable {
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     @available(*, deprecated: 3.18.0, message: "Please use Swift.Codable instead")
     public func mapping(map: Map) {
-        lmt <- (CodingKeys.lastModifiedTime.rawValue, map[CodingKeys.lastModifiedTime.rawValue])
-        ect <- (CodingKeys.entityCreationTime.rawValue, map[CodingKeys.entityCreationTime.rawValue])
-        authtoken <- (CodingKeys.authtoken.rawValue, map[CodingKeys.authtoken.rawValue])
+        lmt <- (CodingKeys.lastModifiedTime.rawValue, map[CodingKeys.lastModifiedTime])
+        ect <- (CodingKeys.entityCreationTime.rawValue, map[CodingKeys.entityCreationTime])
+        authtoken <- (CodingKeys.authtoken.rawValue, map[CodingKeys.authtoken])
     }
 
 }
@@ -234,9 +234,9 @@ public final class UserMetadata: Metadata {
     public override func mapping(map: Map) {
         super.mapping(map: map)
         
-        emailVerification <- (UserMetadataCodingKeys.emailVerification.rawValue, map[UserMetadataCodingKeys.emailVerification.rawValue])
-        passwordReset <- (UserMetadataCodingKeys.passwordReset.rawValue, map[UserMetadataCodingKeys.passwordReset.rawValue])
-        userStatus <- (UserMetadataCodingKeys.userStatus.rawValue, map[UserMetadataCodingKeys.userStatus.rawValue])
+        emailVerification <- (UserMetadataCodingKeys.emailVerification.rawValue, map[UserMetadataCodingKeys.emailVerification])
+        passwordReset <- (UserMetadataCodingKeys.passwordReset.rawValue, map[UserMetadataCodingKeys.passwordReset])
+        userStatus <- (UserMetadataCodingKeys.userStatus.rawValue, map[UserMetadataCodingKeys.userStatus])
     }
 
 }
@@ -327,9 +327,9 @@ extension EmailVerification: Mappable {
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
         status <- (EmailVerificationCodingKeys.status.rawValue, map[EmailVerificationCodingKeys.status])
-        lsca <- (EmailVerificationCodingKeys.lastStateChangeAt.rawValue, map[EmailVerificationCodingKeys.lastStateChangeAt.rawValue])
-        lca <- (EmailVerificationCodingKeys.lastConfirmedAt.rawValue, map[EmailVerificationCodingKeys.lastConfirmedAt.rawValue])
-        emailAddress <- (EmailVerificationCodingKeys.emailAddress.rawValue, map[EmailVerificationCodingKeys.emailAddress.rawValue])
+        lsca <- (EmailVerificationCodingKeys.lastStateChangeAt.rawValue, map[EmailVerificationCodingKeys.lastStateChangeAt])
+        lca <- (EmailVerificationCodingKeys.lastConfirmedAt.rawValue, map[EmailVerificationCodingKeys.lastConfirmedAt])
+        emailAddress <- (EmailVerificationCodingKeys.emailAddress.rawValue, map[EmailVerificationCodingKeys.emailAddress])
     }
     
 }
@@ -397,8 +397,8 @@ extension PasswordReset: Mappable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        status <- (PasswordResetCodingKeys.status.rawValue, map[PasswordResetCodingKeys.status.rawValue])
-        lsca <- (PasswordResetCodingKeys.lastStateChangeAt.rawValue, map[PasswordResetCodingKeys.lastStateChangeAt.rawValue])
+        status <- (PasswordResetCodingKeys.status.rawValue, map[PasswordResetCodingKeys.status])
+        lsca <- (PasswordResetCodingKeys.lastStateChangeAt.rawValue, map[PasswordResetCodingKeys.lastStateChangeAt])
     }
     
 }

--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -130,9 +130,9 @@ public class Metadata: Object, Codable {
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     @available(*, deprecated: 3.18.0, message: "Please use Swift.Codable instead")
     public func mapping(map: Map) {
-        lmt <- (CodingKeys.lastModifiedTime.rawValue, map[CodingKeys.lastModifiedTime])
-        ect <- (CodingKeys.entityCreationTime.rawValue, map[CodingKeys.entityCreationTime])
-        authtoken <- (CodingKeys.authtoken.rawValue, map[CodingKeys.authtoken])
+        lmt <- (CodingKeys.lastModifiedTime.rawValue, map[CodingKeys.lastModifiedTime.rawValue])
+        ect <- (CodingKeys.entityCreationTime.rawValue, map[CodingKeys.entityCreationTime.rawValue])
+        authtoken <- (CodingKeys.authtoken.rawValue, map[CodingKeys.authtoken.rawValue])
     }
 
 }
@@ -234,9 +234,9 @@ public final class UserMetadata: Metadata {
     public override func mapping(map: Map) {
         super.mapping(map: map)
         
-        emailVerification <- ("emailVerification", map["emailVerification"])
-        passwordReset <- ("passwordReset", map["passwordReset"])
-        userStatus <- ("status", map["status"])
+        emailVerification <- (UserMetadataCodingKeys.emailVerification.rawValue, map[UserMetadataCodingKeys.emailVerification.rawValue])
+        passwordReset <- (UserMetadataCodingKeys.passwordReset.rawValue, map[UserMetadataCodingKeys.passwordReset.rawValue])
+        userStatus <- (UserMetadataCodingKeys.userStatus.rawValue, map[UserMetadataCodingKeys.userStatus.rawValue])
     }
 
 }
@@ -244,18 +244,75 @@ public final class UserMetadata: Metadata {
 /// Status of the email verification process for each `User`
 public final class EmailVerification: Object, Codable {
     
+    @objc
+    internal dynamic var lsca: String?
+    
+    @objc
+    internal dynamic var lca: String?
+    
     /// Current Status
     open internal(set) var status: String?
     
     /// Date of the last Status change
-    open internal(set) var lastStateChangeAt: Date?
+    open var lastStateChangeAt: Date? {
+        get {
+            return self.lsca?.toDate()
+        }
+        set {
+            lsca = newValue?.toString()
+        }
+    }
     
     /// Date of the last email confirmation
-    open internal(set) var lastConfirmedAt: Date?
+    open var lastConfirmedAt: Date? {
+        get {
+            return self.lca?.toDate()
+        }
+        set {
+            lca = newValue?.toString()
+        }
+    }
     
     /// Email Address
     open internal(set) var emailAddress: String?
     
+    public required init() {
+        super.init()
+    }
+    
+    enum EmailVerificationCodingKeys: String, CodingKey {
+        
+        case status
+        case lastStateChangeAt
+        case lastConfirmedAt
+        case emailAddress
+        
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: EmailVerificationCodingKeys.self)
+        status = try container.decodeIfPresent(String.self, forKey: .status)
+        lsca = try container.decodeIfPresent(String.self, forKey: .lastStateChangeAt)
+        lca = try container.decodeIfPresent(String.self, forKey: .lastConfirmedAt)
+        emailAddress = try container.decodeIfPresent(String.self, forKey: .emailAddress)
+        super.init()
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: EmailVerificationCodingKeys.self)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(lsca, forKey: .lastStateChangeAt)
+        try container.encodeIfPresent(lca, forKey: .lastConfirmedAt)
+        try container.encodeIfPresent(emailAddress, forKey: .emailAddress)
+    }
+    
+    public required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    public required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
 }
 
 /// Allows serialization and deserialization of EmailVerification
@@ -269,10 +326,10 @@ extension EmailVerification: Mappable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        status <- ("status", map["status"])
-        lastStateChangeAt <- ("lastStateChangeAt", map["lastStateChangeAt"], KinveyDateTransform())
-        lastConfirmedAt <- ("lastConfirmedAt", map["lastConfirmedAt"], KinveyDateTransform())
-        emailAddress <- ("emailAddress", map["emailAddress"])
+        status <- (EmailVerificationCodingKeys.status.rawValue, map[EmailVerificationCodingKeys.status])
+        lsca <- (EmailVerificationCodingKeys.lastStateChangeAt.rawValue, map[EmailVerificationCodingKeys.lastStateChangeAt.rawValue])
+        lca <- (EmailVerificationCodingKeys.lastConfirmedAt.rawValue, map[EmailVerificationCodingKeys.lastConfirmedAt.rawValue])
+        emailAddress <- (EmailVerificationCodingKeys.emailAddress.rawValue, map[EmailVerificationCodingKeys.emailAddress.rawValue])
     }
     
 }
@@ -280,12 +337,53 @@ extension EmailVerification: Mappable {
 /// Status of the password reset process for each `User`
 public final class PasswordReset: Object, Codable {
     
+    @objc
+    internal dynamic var lsca: String?
+    
     /// Current Status
     open internal(set) var status: String?
     
     /// Date of the last Status change
-    open internal(set) var lastStateChangeAt: Date?
+    open var lastStateChangeAt: Date? {
+        get {
+            return self.lsca?.toDate()
+        }
+        set {
+            lsca = newValue?.toString()
+        }
+    }
     
+    public required init() {
+        super.init()
+    }
+    
+    enum PasswordResetCodingKeys: String, CodingKey {
+        
+        case status
+        case lastStateChangeAt
+        
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PasswordResetCodingKeys.self)
+        status = try container.decodeIfPresent(String.self, forKey: .status)
+        lsca = try container.decodeIfPresent(String.self, forKey: .lastStateChangeAt)
+        super.init()
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PasswordResetCodingKeys.self)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(lsca, forKey: .lastStateChangeAt)
+    }
+    
+    public required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    public required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
 }
 
 /// Allows serialization and deserialization of PasswordReset
@@ -299,8 +397,8 @@ extension PasswordReset: Mappable {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        status <- ("status", map["status"])
-        lastStateChangeAt <- ("lastStateChangeAt", map["lastStateChangeAt"], KinveyDateTransform())
+        status <- (PasswordResetCodingKeys.status.rawValue, map[PasswordResetCodingKeys.status.rawValue])
+        lsca <- (PasswordResetCodingKeys.lastStateChangeAt.rawValue, map[PasswordResetCodingKeys.lastStateChangeAt.rawValue])
     }
     
 }

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -949,11 +949,13 @@ open class User: NSObject, Credential {
         socialIdentity = anotherUser.socialIdentity
         username = anotherUser.username
         email = anotherUser.email
-        for child in Mirror(reflecting: anotherUser).children {
-            guard let label = child.label else {
-                continue
+        if (type(of: self) != User.self) {
+            for child in Mirror(reflecting: anotherUser).children {
+                guard let label = child.label else {
+                    continue
+                }
+                setValue(child.value, forKey: label)
             }
-            setValue(child.value, forKey: label)
         }
     }
     

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -949,6 +949,12 @@ open class User: NSObject, Credential {
         socialIdentity = anotherUser.socialIdentity
         username = anotherUser.username
         email = anotherUser.email
+        for child in Mirror(reflecting: anotherUser).children {
+            guard let label = child.label else {
+                continue
+            }
+            setValue(child.value, forKey: label)
+        }
     }
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -395,6 +395,8 @@ class KinveyTestCase: XCTestCase {
         if let activeUser = client.activeUser {
             activeUser.logout()
         }
+        
+        client.userType = User.self
     }
     
     class SignUpMockURLProtocol: URLProtocol {
@@ -587,6 +589,8 @@ class KinveyTestCase: XCTestCase {
         removeAll(Person.self)
         
         Kinvey.logLevel = originalLogLevel
+        
+        client.userType = User.self
         
         super.tearDown()
     }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -1125,38 +1125,14 @@ class UserTests: KinveyTestCase {
         }
     }
     
-    class MyUser: User, Codable {
+    class MyUser: User {
         
         var foo: String?
-        
-        enum MyUserCodingKeys: String, CodingKey {
-            case foo
-        }
-        
-        required init(from decoder: Decoder) throws {
-            try super.init(from: decoder)
-            let container = try decoder.container(keyedBy: MyUserCodingKeys.self)
-            self.foo = try container.decodeIfPresent(String.self, forKey: .foo)
-        }
-        
-        override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-            var container = encoder.container(keyedBy: MyUserCodingKeys.self)
-            try container.encodeIfPresent(self.foo, forKey: .foo)
-        }
-        
-        init() {
-            super.init()
-        }
-        
-        required init?(map: Map) {
-            super.init(map: map)
-        }
         
         override func mapping(map: Map) {
             super.mapping(map: map)
             
-            foo <- (MyUserCodingKeys.foo.rawValue, map[MyUserCodingKeys.foo.rawValue])
+            foo <- map["foo"]
         }
         
     }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -1125,14 +1125,38 @@ class UserTests: KinveyTestCase {
         }
     }
     
-    class MyUser: User {
+    class MyUser: User, Codable {
         
         var foo: String?
+        
+        enum MyUserCodingKeys: String, CodingKey {
+            case foo
+        }
+        
+        required init(from decoder: Decoder) throws {
+            try super.init(from: decoder)
+            let container = try decoder.container(keyedBy: MyUserCodingKeys.self)
+            self.foo = try container.decodeIfPresent(String.self, forKey: .foo)
+        }
+        
+        override func encode(to encoder: Encoder) throws {
+            try super.encode(to: encoder)
+            var container = encoder.container(keyedBy: MyUserCodingKeys.self)
+            try container.encodeIfPresent(self.foo, forKey: .foo)
+        }
+        
+        init() {
+            super.init()
+        }
+        
+        required init?(map: Map) {
+            super.init(map: map)
+        }
         
         override func mapping(map: Map) {
             super.mapping(map: map)
             
-            foo <- map["foo"]
+            foo <- (MyUserCodingKeys.foo.rawValue, map[MyUserCodingKeys.foo.rawValue])
         }
         
     }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -1342,7 +1342,7 @@ class UserTests: KinveyTestCase {
     
     class MyCodableUser: User, Codable {
         
-        var foo: String?
+        @objc dynamic var foo: String?
         
         enum MyCodableUserCodingKeys: String, CodingKey {
             case foo
@@ -1391,6 +1391,7 @@ class UserTests: KinveyTestCase {
             if useMockData {
                 mockResponse(completionHandler: { (request) -> HttpResponse in
                     let json = try! JSONSerialization.jsonObject(with: request) as! JsonDictionary
+                    XCTAssertEqual(json["foo"] as? String, "bar")
                     return HttpResponse(json: json)
                 })
             }

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -1378,6 +1378,9 @@ class UserTests: KinveyTestCase {
     
     func testSaveCustomCodableUser() {
         client.userType = MyCodableUser.self
+        defer {
+            client.userType = User.self
+        }
         
         let user = MyCodableUser()
         user.foo = "bar"
@@ -1428,6 +1431,9 @@ class UserTests: KinveyTestCase {
     
     func testRefreshCustomCodableUser() {
         client.userType = MyCodableUser.self
+        defer {
+            client.userType = User.self
+        }
         
         signUp(mustIncludeSocialIdentity: false)
         


### PR DESCRIPTION
#### Description
`EmailVerification` and `PasswordReset` metadata objects which are a part of `UserMetadata` do not have the `Codable` protocol implemented. This caused the `User` object to fail to initialize using `init(from:)` with the following error:

![screen shot 2018-09-10 at 10 50 05](https://user-images.githubusercontent.com/6303466/45295742-16167c80-b500-11e8-9d94-e5e735ecee89.png)

#### Changes
Implemented `Codable` for both `EmailVerification` and `PasswordReset` objects. Also updated the `mapping(map:)` method of `Metadata` as it seems it wasn't passing the correct keys to `map`.

#### Tests
Tested in an app making use of Kinvey user accounts, the above mentioned error is gone, checked that all of the data was correctly parsed and available inside the `User` instance.