### PR TITLE
MLIBZ-2670: storing the correct refresh token

### DIFF
--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -427,11 +427,13 @@ internal class HttpRequest<Result>: TaskProgressRequest, Request {
                     }
                 }
                 if response.statusCode == 401,
-                    let user = self.credential as? User,
-                    let socialIdentity = user.socialIdentity,
-                    let kinveyAuthToken = socialIdentity.kinvey,
-                    let refreshToken = kinveyAuthToken["refresh_token"] as? String
+                    let user = self.credential as? User
                 {
+                    guard let refreshToken = user.refreshToken else {
+                        user.logout()
+                        completionHandler?(data, HttpResponse(response: response), error)
+                        return
+                    }
                     let options = try! Options(self.options, authServiceId: self.client.clientId)
                     MIC.login(refreshToken: refreshToken, options: options) {
                         switch $0 {

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -46,6 +46,8 @@ open class User: NSObject, Credential {
     /// `_kmd` property of the user.
     open fileprivate(set) var metadata: UserMetadata?
     
+    internal fileprivate(set) var refreshToken: String?
+    
     /// `_socialIdentity` property of the user.
     open fileprivate(set) var socialIdentity: UserSocialIdentity?
     
@@ -379,6 +381,7 @@ open class User: NSObject, Credential {
             }
             requests += request
         }.done { user in
+            user.refreshToken = authData["refresh_token"] as? String
             client.activeUser = user
             client.clientId = options?.authServiceId
             completionHandler?(.success(user))
@@ -920,6 +923,7 @@ open class User: NSObject, Credential {
         _userId = try container.decode(String.self, forKey: .userId)
         acl = try container.decodeIfPresent(Acl.self, forKey: .acl)
         metadata = try container.decodeIfPresent(UserMetadata.self, forKey: .metadata)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
         username = try container.decodeIfPresent(String.self, forKey: .username)
         email = try container.decodeIfPresent(String.self, forKey: .email)
         super.init()
@@ -930,6 +934,7 @@ open class User: NSObject, Credential {
         try container.encodeIfPresent(_userId, forKey: .userId)
         try container.encodeIfPresent(acl, forKey: .acl)
         try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
         try container.encodeIfPresent(username, forKey: .username)
         try container.encodeIfPresent(email, forKey: .email)
     }
@@ -965,6 +970,7 @@ open class User: NSObject, Credential {
         _userId <- ("_userId", map[Entity.EntityCodingKeys.entityId])
         acl <- ("acl", map[Entity.EntityCodingKeys.acl])
         metadata <- ("metadata", map[Entity.EntityCodingKeys.metadata])
+        refreshToken <- ("refreshToken", map[CodingKeys.refreshToken])
         socialIdentity <- ("socialIdentity", map["_socialIdentity"])
         username <- ("username", map["username"])
         email <- ("email", map["email"])
@@ -1576,6 +1582,7 @@ extension User {
         case userId = "_id"
         case acl = "_acl"
         case metadata = "_kmd"
+        case refreshToken = "refresh_token"
         case socialIdentity = "_socialIdentity"
         case username
         case email

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -1238,6 +1238,11 @@ class SyncStoreTests: StoreTestCase {
     }
     
     func testPushError401EmptyBody() {
+        signUp()
+        
+        XCTAssertNotNil(client.activeUser)
+        XCTAssertEqual(store.syncCount(), 0)
+        
         save()
         
         defer {
@@ -1269,7 +1274,8 @@ class SyncStoreTests: StoreTestCase {
             expectationPush = nil
         }
         
-        XCTAssertEqual(store.syncCount(), 1)
+        XCTAssertEqual(store.syncCount(), 0)
+        XCTAssertNil(client.activeUser)
     }
     
     func testPushInvalidDataStoreType() {

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -2867,8 +2867,10 @@ class UserTests: KinveyTestCase {
             
             static let code = "7af647ad1414986bec71d7799ced85fd271050a8"
             static let tempLoginUri = "https://auth.kinvey.com/oauth/authenticate/b3ca941c1141468bb19d2f2c7409f7a6"
+            static let refreshToken = "dc6118e98b8c004a6e2d3e2aa985f57e40a87a02"
             lazy var code: String = MICLoginAutomatedAuthorizationGrantFlowURLProtocol.code
             lazy var tempLoginUri: String = MICLoginAutomatedAuthorizationGrantFlowURLProtocol.tempLoginUri
+            lazy var refreshToken: String = MICLoginAutomatedAuthorizationGrantFlowURLProtocol.refreshToken
             static var count = 0
             
             override class func canInit(with request: URLRequest) -> Bool {
@@ -2919,7 +2921,7 @@ class UserTests: KinveyTestCase {
                         "access_token" : "7f3fe7847a7292994c87fa322405cb8e03b7bf9c",
                         "token_type" : "bearer",
                         "expires_in" : 3599,
-                        "refresh_token" : "dc6118e98b8c004a6e2d3e2aa985f57e40a87a02"
+                        "refresh_token" : refreshToken
                     ] as [String : Any]
                     let data = try! JSONSerialization.data(withJSONObject: json)
                     client?.urlProtocol(self, didLoad: data)
@@ -3055,6 +3057,12 @@ class UserTests: KinveyTestCase {
         }
         
         XCTAssertNotNil(client.activeUser)
+        
+        guard let user = client.activeUser else {
+            return
+        }
+        
+        XCTAssertEqual(user.refreshToken, MICLoginAutomatedAuthorizationGrantFlowURLProtocol.refreshToken)
         
         do {
             let store = try! DataStore<Person>.collection(.network)


### PR DESCRIPTION
#### Description

Storing the refresh token obtained by the `/oauth/token` endpoint

#### Changes

- `User` now have a `refreshToken` property 

#### Tests

- Same unit tests but making sure the refresh token value stored is the right value
