### PR TITLE
MLIBZ-2686: Adding basic support for command line apps

### DIFF
--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -155,7 +155,7 @@ let groupId = "_group_"
         if let xcTestConfigurationFilePath = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] {
             return URL(fileURLWithPath: xcTestConfigurationFilePath).deletingLastPathComponent().path
         } else {
-            return URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!).appendingPathComponent(Bundle.main.bundleIdentifier!).path
+            return URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!).appendingPathComponent(Bundle.main.bundleIdentifier ?? ProcessInfo.processInfo.processName).path
         }
     }()
 #else


### PR DESCRIPTION
#### Description

Adding basic support for command line apps

#### Changes

- CLI apps does not have a bundle, so because of that the `ProcessInfo.processName` should be used

#### Tests

- Same tests
