### PR TITLE
MLIBZ-2688: bugfix for crash when a non-objc property is set

### DIFF
--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -941,7 +941,7 @@ open class User: NSObject, Credential {
         try container.encodeIfPresent(email, forKey: .email)
     }
     
-    open func refresh<UserType: User>(anotherUser: UserType) {
+    open func refresh<UserType: User>(anotherUser: UserType, refreshCustomProperties: Bool = true) {
         _userId = anotherUser.userId
         acl = anotherUser.acl
         if let authtoken = metadata?.authtoken,
@@ -956,7 +956,7 @@ open class User: NSObject, Credential {
         socialIdentity = anotherUser.socialIdentity
         username = anotherUser.username
         email = anotherUser.email
-        if (type(of: self) != User.self) {
+        if refreshCustomProperties, type(of: self) != User.self {
             for child in Mirror(reflecting: anotherUser).children {
                 guard let label = child.label else {
                     continue

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -1651,6 +1651,14 @@ extension User /* Equatable */ {
 
 }
 
+extension User {
+    
+    open override func setValue(_ value: Any?, forUndefinedKey key: String) {
+        log.warning("Value for property \(type(of: self)).\(key) cannot not be set. Please override the \(#function) method.")
+    }
+    
+}
+
 /// Holds the Social Identities attached to a specific User
 public struct UserSocialIdentity {
     

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -1343,9 +1343,11 @@ class UserTests: KinveyTestCase {
     class MyCodableUser: User, Codable {
         
         @objc dynamic var foo: String?
+        var nonObjCProperty: String?
         
         enum MyCodableUserCodingKeys: String, CodingKey {
             case foo
+            case nonObjCProperty
         }
         
         required init(from decoder: Decoder) throws {
@@ -1371,7 +1373,8 @@ class UserTests: KinveyTestCase {
         override func mapping(map: Map) {
             super.mapping(map: map)
             
-            foo <- (MyCodableUserCodingKeys.foo.rawValue, map[MyCodableUserCodingKeys.foo.rawValue])
+            foo <- (MyCodableUserCodingKeys.foo.rawValue, map[MyCodableUserCodingKeys.foo])
+            nonObjCProperty <- (MyCodableUserCodingKeys.nonObjCProperty.rawValue, map[MyCodableUserCodingKeys.nonObjCProperty])
         }
         
     }


### PR DESCRIPTION
#### Description

Bugfix for crash when a non-objc property is set during refresh()

#### Changes

- `User` now overrides `setValue(_:forUndefinedKey:)` to avoid crashes

#### Tests

- A few changes in the custom user refresh unit test
