### PR TITLE
MLIBZ-2725: Be able to store dates as ISO 8601 strings

### DIFF
--- a/Kinvey/Kinvey/Date.swift
+++ b/Kinvey/Kinvey/Date.swift
@@ -14,4 +14,8 @@ extension Date {
         return KinveyDateTransform().transformToJSON(self)!
     }
     
+    public func toISO8601() -> String {
+        return toString()
+    }
+    
 }

--- a/Kinvey/Kinvey/Date.swift
+++ b/Kinvey/Kinvey/Date.swift
@@ -9,13 +9,9 @@
 import Foundation
 
 extension Date {
-    
-    func toString() -> String {
-        return KinveyDateTransform().transformToJSON(self)!
-    }
-    
+
     public func toISO8601() -> String {
-        return toString()
+        return KinveyDateTransform().transformToJSON(self)!
     }
     
 }

--- a/Kinvey/Kinvey/Endpoint.swift
+++ b/Kinvey/Kinvey/Endpoint.swift
@@ -115,7 +115,7 @@ internal enum Endpoint {
             let url = client.apiHostName.appendingPathComponent("/appdata/\(client.appKey!)/\(collectionName)/_deltaset")
             var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
             var queryItems = urlComponents.queryItems ?? []
-            queryItems.append(URLQueryItem(name: "since", value: sinceDate.toString()))
+            queryItems.append(URLQueryItem(name: "since", value: sinceDate.toISO8601()))
             urlComponents.queryItems = queryItems
             return translate(url: urlComponents.url!, query: query)
         case .appDataCount(let client, let collectionName, let query):

--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -55,7 +55,7 @@ public class Metadata: Object, Codable {
             return self.lmt?.toDate()
         }
         set {
-            lmt = newValue?.toString()
+            lmt = newValue?.toISO8601()
         }
     }
     
@@ -65,7 +65,7 @@ public class Metadata: Object, Codable {
             return self.ect?.toDate()
         }
         set {
-            ect = newValue?.toString()
+            ect = newValue?.toISO8601()
         }
     }
     
@@ -257,7 +257,7 @@ public final class EmailVerification: Object, Codable {
             return self.lsca?.toDate()
         }
         set {
-            lsca = newValue?.toString()
+            lsca = newValue?.toISO8601()
         }
     }
     
@@ -267,7 +267,7 @@ public final class EmailVerification: Object, Codable {
             return self.lca?.toDate()
         }
         set {
-            lca = newValue?.toString()
+            lca = newValue?.toISO8601()
         }
     }
     
@@ -347,7 +347,7 @@ public final class PasswordReset: Object, Codable {
             return self.lsca?.toDate()
         }
         set {
-            lsca = newValue?.toString()
+            lsca = newValue?.toISO8601()
         }
     }
     

--- a/Kinvey/KinveyTests/AclTestCase.swift
+++ b/Kinvey/KinveyTests/AclTestCase.swift
@@ -97,8 +97,8 @@ class AclTestCase: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -218,8 +218,8 @@ class AclTestCase: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -275,8 +275,8 @@ class AclTestCase: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -340,8 +340,8 @@ class AclTestCase: StoreTestCase {
                         "creator" : sharedClient.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -405,8 +405,8 @@ class AclTestCase: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }

--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -80,8 +80,8 @@ class CacheStoreTests: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -197,8 +197,8 @@ class CacheStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                     return HttpResponse(json: json)
@@ -351,8 +351,8 @@ class CacheStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                     mockJson = json
@@ -480,7 +480,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -560,7 +560,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -612,7 +612,7 @@ class CacheStoreTests: StoreTestCase {
     //Create 1 person, Make regular GET, Create 1 more person, Make deltaset request
     func testCacheStoreDeltaset1ExtraItemAddedWithPull() {
         let store = try! DataStore<Person>.collection(.cache, options: try! Options(deltaSet: true))
-        var sinceTime = Date().toString()
+        var sinceTime = Date().toISO8601()
         var initialCount = Int64(0)
         do {
             if !useMockData {
@@ -629,7 +629,7 @@ class CacheStoreTests: StoreTestCase {
                     }
                     switch url.path {
                     case "/appdata/_kid_/\(Person.collectionName())":
-                        sinceTime = Date().toString()
+                        sinceTime = Date().toISO8601()
                         let json = [
                             [
                                 "_id": "58450d87f29e22207c83a236",
@@ -704,7 +704,7 @@ class CacheStoreTests: StoreTestCase {
                         XCTAssert(sinceTime == sinceInRequest)
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -802,7 +802,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -858,7 +858,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -944,7 +944,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1009,7 +1009,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -1084,7 +1084,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -1179,7 +1179,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1250,7 +1250,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -1345,7 +1345,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1416,7 +1416,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -1517,7 +1517,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1573,7 +1573,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -1649,7 +1649,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 [
@@ -1747,7 +1747,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1819,7 +1819,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1900,7 +1900,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -1953,7 +1953,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -2047,7 +2047,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -2100,7 +2100,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -2183,7 +2183,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -2245,7 +2245,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -2316,7 +2316,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -2407,7 +2407,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -2474,7 +2474,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -2565,7 +2565,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -2632,7 +2632,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -2731,7 +2731,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -2784,7 +2784,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -2856,7 +2856,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 [
@@ -2950,7 +2950,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3030,7 +3030,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3114,7 +3114,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3175,7 +3175,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -3279,7 +3279,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3340,7 +3340,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -3431,7 +3431,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3501,7 +3501,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -3581,7 +3581,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -3680,7 +3680,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3756,7 +3756,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -3855,7 +3855,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3931,7 +3931,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -4038,7 +4038,7 @@ class CacheStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4099,7 +4099,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -4179,7 +4179,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 [
@@ -4283,7 +4283,7 @@ class CacheStoreTests: StoreTestCase {
                         ] as JsonDictionary
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4335,7 +4335,7 @@ class CacheStoreTests: StoreTestCase {
                     case "/appdata/_kid_/\(Person.collectionName())/\(idToFind)":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "_id": idToFind,

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -82,8 +82,8 @@ class DataTypeTestCase: StoreTestCase {
                     "creator" : UUID().uuidString
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ]
         ])
@@ -143,13 +143,13 @@ class DataTypeTestCase: StoreTestCase {
             mockResponse(json: [
                 [
                     "_id" : UUID().uuidString,
-                    "date" : Date().toString(),
+                    "date" : Date().toISO8601(),
                     "_acl" : [
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ]
             ])
@@ -194,13 +194,13 @@ class DataTypeTestCase: StoreTestCase {
             mockResponse(json: [
                 [
                     "_id" : UUID().uuidString,
-                    "date" : Date().toString(),
+                    "date" : Date().toISO8601(),
                     "_acl" : [
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ]
             ])

--- a/Kinvey/KinveyTests/DateTestCase.swift
+++ b/Kinvey/KinveyTests/DateTestCase.swift
@@ -52,7 +52,7 @@ class DateTestCase: KinveyTestCase {
         let transform = AnyTransform(KinveyDateTransform())
         
         let date = Date()
-        let dateString = date.toString()
+        let dateString = date.toISO8601()
         
         XCTAssertEqual(date.timeIntervalSinceReferenceDate, (transform.transformFromJSON(dateString) as! Date).timeIntervalSinceReferenceDate, accuracy: 0.0009)
         XCTAssertEqual(dateString, transform.transformToJSON(date) as? String)
@@ -73,13 +73,13 @@ class DateTestCase: KinveyTestCase {
         for _ in 1...nEvents {
             if useMockData {
                 let json: JsonDictionary = [
-                    "date" : publishDate.toString(),
+                    "date" : publishDate.toISO8601(),
                     "_acl" : [
                         "creator" : client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ],
                     "_id" : UUID().uuidString
                 ]

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -57,19 +57,19 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         do {
             let person = Person()
             person.personId = "update"
-            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toISO8601()])
             cache.save(entity: person)
         }
         do {
             let person = Person()
             person.personId = "noChange"
-            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toISO8601()])
             cache.save(entity: person)
         }
         do {
             let person = Person()
             person.personId = "delete"
-            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()])
+            person.metadata = Metadata(JSON: [Metadata.CodingKeys.lastModifiedTime.rawValue : date.toISO8601()])
             cache.save(entity: person)
         }
         let operation = Operation(
@@ -83,19 +83,19 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             [
                 Entity.EntityCodingKeys.entityId.rawValue : "create",
                 Entity.EntityCodingKeys.metadata.rawValue : [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString(),
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toISO8601(),
                 ]
             ],
             [
                 Entity.EntityCodingKeys.entityId.rawValue : "update",
                 Entity.EntityCodingKeys.metadata.rawValue : [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date(timeInterval: 1, since: date).toString()
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date(timeInterval: 1, since: date).toISO8601()
                 ]
             ],
             [
                 Entity.EntityCodingKeys.entityId.rawValue : "noChange",
                 Entity.EntityCodingKeys.metadata.rawValue : [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toString()
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : date.toISO8601()
                 ]
             ]
         ]
@@ -136,8 +136,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                     ])
             }
@@ -187,8 +187,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -259,8 +259,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator" : client.activeUser!.userId
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ],
                     [
@@ -271,8 +271,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator" : client.activeUser!.userId
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 ])
@@ -332,8 +332,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator": client.activeUser?.userId
                     ],
                     "_kmd": [
-                        "lmt": Date().toString(),
-                        "ect": Date().toString()
+                        "lmt": Date().toISO8601(),
+                        "ect": Date().toISO8601()
                     ]
                 ])
             }
@@ -387,8 +387,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator": client.activeUser?.userId
                     ],
                     "_kmd": [
-                        "lmt": Date().toString(),
-                        "ect": Date().toString()
+                        "lmt": Date().toISO8601(),
+                        "ect": Date().toISO8601()
                     ]
                 ])
             }
@@ -459,8 +459,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator": client.activeUser?.userId
                         ],
                         "_kmd": [
-                            "lmt": Date().toString(),
-                            "ect": Date().toString()
+                            "lmt": Date().toISO8601(),
+                            "ect": Date().toISO8601()
                         ]
                     ]
                 ])
@@ -516,8 +516,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -669,8 +669,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser?.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -719,8 +719,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser?.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -1252,7 +1252,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator": client.activeUser?.userId
                         ],
                         "_kmd": [
-                            "lmt": Date().toString()
+                            "lmt": Date().toISO8601()
                         ]
                     ]
                 ])
@@ -1401,8 +1401,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : client.activeUser?.userId
                     ],
                     "_kmd" : [
-                        "lmt" : mockDate?.toString(),
-                        "ect" : mockDate?.toString()
+                        "lmt" : mockDate?.toISO8601(),
+                        "ect" : mockDate?.toISO8601()
                     ]
                 ])
             }
@@ -1435,7 +1435,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     mockCount += 1
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             [
                                 "_id" : mockObjectId!,
@@ -1445,8 +1445,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser?.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : mockDate?.toString(),
-                                    "ect" : mockDate?.toString()
+                                    "lmt" : mockDate?.toISO8601(),
+                                    "ect" : mockDate?.toISO8601()
                                 ]
                             ]
                         ]
@@ -1489,7 +1489,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     mockCount += 1
                     XCTAssertEqual(request.url!.path, "/appdata/_kid_/Person/_deltaset")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             "changed" : [],
                             "deleted" : []
@@ -1567,8 +1567,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : client.activeUser?.userId
                     ],
                     "_kmd" : [
-                        "lmt" : mockDate?.toString(),
-                        "ect" : mockDate?.toString()
+                        "lmt" : mockDate?.toISO8601(),
+                        "ect" : mockDate?.toISO8601()
                     ]
                 ])
             }
@@ -1602,7 +1602,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     mockCount += 1
                     XCTAssertEqual(request.url!.path, "/appdata/_kid_/Person")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             [
                                 "_id" : mockObjectId!,
@@ -1612,8 +1612,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser?.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date(timeInterval: 1, since: mockDate!).toString(),
-                                    "ect" : mockDate?.toString()
+                                    "lmt" : Date(timeInterval: 1, since: mockDate!).toISO8601(),
+                                    "ect" : mockDate?.toISO8601()
                                 ]
                             ]
                         ]
@@ -1656,7 +1656,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     mockCount += 1
                     XCTAssertEqual(request.url!.path, "/appdata/_kid_/Person/_deltaset")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             "changed" : [
                                 [
@@ -1667,8 +1667,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser?.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date(timeInterval: 1, since: mockDate!).toString(),
-                                        "ect" : mockDate?.toString()
+                                        "lmt" : Date(timeInterval: 1, since: mockDate!).toISO8601(),
+                                        "ect" : mockDate?.toISO8601()
                                     ]
                                 ]
                             ],
@@ -1723,7 +1723,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     XCTAssertEqual(fields.last, "age")
                     XCTAssertEqual(urlComponents.path, "/appdata/_kid_/Person/")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             [
                                 "_id" : mockObjectId!,
@@ -1779,7 +1779,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     XCTAssertEqual(fields.last, "age")
                     XCTAssertEqual(urlComponents.path, "/appdata/_kid_/Person/_deltaset")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             "changed" : [
                                 [
@@ -1896,7 +1896,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         do {
             if useMockData {
                 mockResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: [
                         [
                             "_id" : mockObjectId!,
@@ -1944,7 +1944,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     mockCount += 1
                     XCTAssertEqual(request.url!.path, "/appdata/_kid_/Person/_deltaset")
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             "changed" : [
                                 [
@@ -1955,8 +1955,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser?.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date(timeInterval: 1, since: mockDate!).toString(),
-                                        "ect" : mockDate?.toString()
+                                        "lmt" : Date(timeInterval: 1, since: mockDate!).toISO8601(),
+                                        "ect" : mockDate?.toISO8601()
                                     ]
                                 ]
                             ],
@@ -2079,8 +2079,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : client.activeUser?.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
             defer {
@@ -2114,14 +2114,14 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : self.client.activeUser!.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
         }
         
         do {
-            mockResponse(headerFields: ["X-Kinvey-Request-Start" : Date().toString()], json: jsonArray)
+            mockResponse(headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()], json: jsonArray)
             defer {
                 setURLProtocol(nil)
             }
@@ -2149,7 +2149,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 let urlComponents = URLComponents(url: response.url!, resolvingAgainstBaseURL: false)!
                 XCTAssertEqual(urlComponents.path.components(separatedBy: "/").last, "_deltaset")
                 return HttpResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: [
                         "changed" : [],
                         "deleted" : []
@@ -2214,8 +2214,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : client.activeUser?.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
             defer {
@@ -2249,8 +2249,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : self.client.activeUser!.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
         }
@@ -2295,8 +2295,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 ])
@@ -2348,8 +2348,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 ])
@@ -2387,7 +2387,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             switch request.url!.path {
             case "/appdata/_kid_/Person":
                 return HttpResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: [
                         [
                             "_id" : UUID().uuidString,
@@ -2397,8 +2397,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                 "creator" : UUID().uuidString
                             ],
                             "_kmd" : [
-                                "lmt" : Date().toString(),
-                                "ect" : Date().toString()
+                                "lmt" : Date().toISO8601(),
+                                "ect" : Date().toISO8601()
                             ]
                         ]
                     ]
@@ -2470,7 +2470,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person":
-                    date1 = Date().toString()
+                    date1 = Date().toISO8601()
                     return HttpResponse(
                         headerFields: ["X-Kinvey-Request-Start" : date1!],
                         json: [
@@ -2482,8 +2482,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ]
                         ]
@@ -2507,7 +2507,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
-                    date2 = Date().toString()
+                    date2 = Date().toISO8601()
                     let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                     let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                     XCTAssertNotNil(since)
@@ -2526,8 +2526,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -2553,7 +2553,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
-                    date3 = Date().toString()
+                    date3 = Date().toISO8601()
                     let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                     let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                     XCTAssertNotNil(since)
@@ -2573,8 +2573,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -2608,7 +2608,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person":
-                    date1 = Date().toString()
+                    date1 = Date().toISO8601()
                     return HttpResponse(
                         headerFields: ["X-Kinvey-Request-Start" : date1!],
                         json: [
@@ -2620,8 +2620,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ]
                         ]
@@ -2645,7 +2645,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
-                    date2 = Date().toString()
+                    date2 = Date().toISO8601()
                     let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                     let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                     XCTAssertNotNil(since)
@@ -2664,8 +2664,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -2691,7 +2691,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
-                    date3 = Date().toString()
+                    date3 = Date().toISO8601()
                     let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                     let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                     XCTAssertNotNil(since)
@@ -2711,8 +2711,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -2754,7 +2754,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date1 = Date().toString()
+                        date1 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date1!],
                             json: [
@@ -2766,8 +2766,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ]
@@ -2815,7 +2815,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date2 = Date().toString()
+                        date2 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -2834,8 +2834,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -2891,7 +2891,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date3 = Date().toString()
+                        date3 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -2911,8 +2911,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -2983,7 +2983,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date1 = Date().toString()
+                        date1 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date1!],
                             json: [
@@ -2995,8 +2995,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ]
@@ -3044,7 +3044,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date2 = Date().toString()
+                        date2 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -3063,8 +3063,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -3120,7 +3120,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date3 = Date().toString()
+                        date3 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -3140,8 +3140,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -3213,7 +3213,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date1 = Date().toString()
+                        date1 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date1!],
                             json: [
@@ -3225,8 +3225,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ]
@@ -3279,7 +3279,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date2 = Date().toString()
+                        date2 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date2!],
                             json: [
@@ -3291,8 +3291,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ],
                                 [
@@ -3303,8 +3303,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                                 
@@ -3357,7 +3357,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date3 = Date().toString()
+                        date3 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -3377,8 +3377,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -3451,7 +3451,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date1 = Date().toString()
+                        date1 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date1!],
                             json: [
@@ -3463,8 +3463,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ]
@@ -3517,7 +3517,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person":
-                        date2 = Date().toString()
+                        date2 = Date().toISO8601()
                         return HttpResponse(
                             headerFields: ["X-Kinvey-Request-Start" : date2!],
                             json: [
@@ -3529,8 +3529,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ],
                                 [
@@ -3541,8 +3541,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                                 
@@ -3595,7 +3595,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 mockResponse { request in
                     switch request.url!.path {
                     case "/appdata/_kid_/Person/_deltaset":
-                        date3 = Date().toString()
+                        date3 = Date().toISO8601()
                         let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                         let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                         XCTAssertNotNil(since)
@@ -3615,8 +3615,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -3680,7 +3680,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person":
-                    date1 = Date().toString()
+                    date1 = Date().toISO8601()
                     return HttpResponse(
                         headerFields: ["x-kinvey-request-start" : date1!],
                         json: [
@@ -3692,8 +3692,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ]
                         ]
@@ -3717,7 +3717,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             mockResponse { request in
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
-                    date2 = Date().toString()
+                    date2 = Date().toISO8601()
                     let urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
                     let since = urlComponents?.queryItems?.filter { $0.name == "since" }.first?.value
                     XCTAssertNotNil(since)
@@ -3736,8 +3736,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -3781,7 +3781,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             let requestStartDate = Date()
                             requestStartDates.append(requestStartDate)
                             return HttpResponse(
-                                headerFields: ["X-Kinvey-Request-Start" : requestStartDate.toString()],
+                                headerFields: ["X-Kinvey-Request-Start" : requestStartDate.toISO8601()],
                                 json: ["count" : 3]
                             )
                         default:
@@ -3801,7 +3801,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                             let requestStartDate = Date()
                             requestStartDates.append(requestStartDate)
                             return HttpResponse(
-                                headerFields: ["X-Kinvey-Request-Start" : requestStartDate.toString()],
+                                headerFields: ["X-Kinvey-Request-Start" : requestStartDate.toISO8601()],
                                 json: [
                                     [
                                         "_id" : UUID().uuidString,
@@ -3811,8 +3811,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ]
@@ -3859,7 +3859,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     switch request.url!.path {
                     case "/appdata/\(sharedClient.appKey!)/\(Person.collectionName())/_deltaset":
                         return HttpResponse(
-                            headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                            headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                             json: [
                                 "changed" : [
                                     [
@@ -3870,8 +3870,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                             "creator" : self.client.activeUser!.userId
                                         ],
                                         "_kmd" : [
-                                            "lmt" : Date().toString(),
-                                            "ect" : Date().toString()
+                                            "lmt" : Date().toISO8601(),
+                                            "ect" : Date().toISO8601()
                                         ]
                                     ]
                                 ],
@@ -3922,7 +3922,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     )
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             [
                                 "_id" : UUID().uuidString,
@@ -3932,8 +3932,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ]
                         ]
@@ -4009,8 +4009,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ])
             }
@@ -4020,7 +4020,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 switch urlComponents.path {
                 case "/appdata/_kid_/Person/_count":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: ["count" : json.count]
                     )
                 case "/appdata/_kid_/Person/_deltaset":
@@ -4036,7 +4036,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     let skip = urlComponents.queryItems?.filter({ $0.name == "skip" && $0.value != nil && Int($0.value!) != nil }).map({ Int($0.value!)! }).first ?? json.startIndex
                     let limit = urlComponents.queryItems?.filter({ $0.name == "limit" && $0.value != nil && Int($0.value!) != nil }).map({ Int($0.value!)! }).first ?? json.endIndex
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: Array(json[skip ..< skip + limit])
                     )
                 default:
@@ -4115,8 +4115,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ],
                 [
@@ -4127,8 +4127,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ]
             ]
@@ -4155,7 +4155,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         }
                     }
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: json
                     )
                 default:
@@ -4227,7 +4227,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 switch request.url!.path {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             [
                                 "_id" : "58450d87f29e22207c83a237",
@@ -4237,8 +4237,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ],
                             [
@@ -4249,8 +4249,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ],
                             [
@@ -4261,8 +4261,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                     "creator" : self.client.activeUser!.userId
                                 ],
                                 "_kmd" : [
-                                    "lmt" : Date().toString(),
-                                    "ect" : Date().toString()
+                                    "lmt" : Date().toISO8601(),
+                                    "ect" : Date().toISO8601()
                                 ]
                             ]
                         ]
@@ -4299,7 +4299,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: [
                             "changed" : [
                                 [
@@ -4310,8 +4310,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                                         "creator" : self.client.activeUser!.userId
                                     ],
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ]
                                 ]
                             ],
@@ -4380,8 +4380,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : self.client.activeUser!.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ],
             [
@@ -4392,8 +4392,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     "creator" : self.client.activeUser!.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ]
         ]
@@ -4424,7 +4424,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     }
                 }
                 return HttpResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: json
                 )
             default:
@@ -4533,8 +4533,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ],
                 [
@@ -4545,8 +4545,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ]
             ]
@@ -4555,7 +4555,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 switch request.url!.path {
                 case "/appdata/_kid_/Person/_count":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: ["count" : json.count]
                     )
                 case "/appdata/_kid_/Person/_deltaset":
@@ -4569,7 +4569,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     )
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: json
                     )
                 default:
@@ -4680,8 +4680,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ],
                 [
@@ -4692,8 +4692,8 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                         "creator" : self.client.activeUser!.userId
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                 ]
             ]
@@ -4704,7 +4704,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 switch urlComponents.path {
                 case "/appdata/_kid_/Person/_count":
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: ["count" : json.count]
                     )
                 case "/appdata/_kid_/Person/_deltaset":
@@ -4725,7 +4725,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                     let skip = urlComponents.queryItems?.filter({ $0.name == "skip" && $0.value != nil && Int($0.value!) != nil }).map({ Int($0.value!)! }).first ?? 0
                     let limit = urlComponents.queryItems?.filter({ $0.name == "limit" && $0.value != nil && Int($0.value!) != nil }).map({ Int($0.value!)! }).first ?? json.endIndex - skip
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: Array(json[skip ..< skip + limit])
                     )
                 default:

--- a/Kinvey/KinveyTests/FileTestCase.swift
+++ b/Kinvey/KinveyTests/FileTestCase.swift
@@ -1660,11 +1660,11 @@ class FileTestCase: StoreTestCase {
                                 "creator": self.client.activeUser?.userId
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)/o?name=\(UUID().uuidString)%2F\(UUID().uuidString)&uploadType=resumable&predefinedAcl=publicRead&upload_id=\(UUID().uuidString)",
-                            "_expiresAt": Date().toString(),
+                            "_expiresAt": Date().toISO8601(),
                             "_requiredHeaders": [
                             ]
                         ])
@@ -1727,8 +1727,8 @@ class FileTestCase: StoreTestCase {
                                 "creator": self.client.activeUser?.userId
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ],
                             "label": "trailer",
                             "_downloadURL": "https://storage.googleapis.com/\(UUID().uuidString)/\(UUID().uuidString)/\(UUID().uuidString)"
@@ -2313,11 +2313,11 @@ class FileTestCase: StoreTestCase {
                                 "creator": self.client.activeUser?.userId
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)/o?name=\(UUID().uuidString)%2F\(UUID().uuidString)&uploadType=resumable&predefinedAcl=publicRead&upload_id=\(UUID().uuidString)",
-                            "_expiresAt": Date().toString(),
+                            "_expiresAt": Date().toISO8601(),
                             "_requiredHeaders": [
                             ]
                         ])
@@ -2350,11 +2350,11 @@ class FileTestCase: StoreTestCase {
                                 "creator": self.client.activeUser?.userId
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ],
                             "_downloadURL": "https://storage.googleapis.com/0b5b1cd673164e3185a2e75e815f5cfe/79d48489-d197-48c8-98e6-b5b4028858a1/4b27cacf-33d2-4c90-b790-271000631895?GoogleAccessId=558440376631@developer.gserviceaccount.com&Expires=1480757466&Signature=djWo6FIonq3gdON80i26xfBnOiGobxxbIVEY5wjVbcBnHpXoUbwDhdK5oPZVkTYkqpABj%2FFNDZpeVDG0UCUL8eS4ujD3%2FwPeHdX2z9cnmNXDLvi%2FPoMQHZg6XatKCQvY6swht6Ybptj5%2Ftx8euHnGLf4l4eTRcwBsDv2mAVz6MU%3D",
-                            "_expiresAt": Date(timeIntervalSinceNow: 3600).toString()
+                            "_expiresAt": Date(timeIntervalSinceNow: 3600).toISO8601()
                         ])
                     default:
                         Swift.fatalError()
@@ -2409,11 +2409,11 @@ class FileTestCase: StoreTestCase {
                                 "creator": self.client.activeUser?.userId
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ],
                             "_downloadURL": "https://storage.googleapis.com/\(UUID().uuidString)/\(UUID().uuidString)/\(UUID().uuidString)?GoogleAccessId=\(UUID().uuidString)@developer.gserviceaccount.com&Expires=\(UUID().uuidString)&Signature=\(UUID().uuidString)%2F\(UUID().uuidString)%2B\(UUID().uuidString)%2B\(UUID().uuidString)%3D",
-                            "_expiresAt": Date(timeIntervalSinceNow: ttl.1.toTimeInterval(ttl.0)).toString()
+                            "_expiresAt": Date(timeIntervalSinceNow: ttl.1.toTimeInterval(ttl.0)).toISO8601()
                         ])
                     case 1:
                         return HttpResponse(data: data)
@@ -2557,11 +2557,11 @@ class FileTestCase: StoreTestCase {
                                     "_id" : "b69d8159-e59f-4337-b03b-1c2df3ccfed9",
                                     "_filename" : "9b77d4f0-43ea-4d70-9f65-e40808d1e429",
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ],
                                     "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=b69d8159-e59f-4337-b03b-1c2df3ccfed9%2F9b77d4f0-43ea-4d70-9f65-e40808d1e429&uploadType=resumable&upload_id=AEnB2Up1heH7qbZXQIqsaT-XJNJTv3OKufiMN_9OXh5qGPVfwP4SaWrU5LW7-ZXswXc11l_Wi027IUjZx44CzajfycP8aam7HQ",
-                                    "_expiresAt" : Date(timeIntervalSinceNow: 7 * TimeUnit.day.timeInterval).toString(),
+                                    "_expiresAt" : Date(timeIntervalSinceNow: 7 * TimeUnit.day.timeInterval).toISO8601(),
                                     "_requiredHeaders" : [
                                     ]
                                 ])
@@ -2575,10 +2575,10 @@ class FileTestCase: StoreTestCase {
                                     "generation": "1486777096687000",
                                     "metageneration": "1",
                                     "contentType": "application/octet-stream",
-                                    "timeCreated": Date().toString(),
-                                    "updated": Date().toString(),
+                                    "timeCreated": Date().toISO8601(),
+                                    "updated": Date().toISO8601(),
                                     "storageClass": "STANDARD",
-                                    "timeStorageClassUpdated": Date().toString(),
+                                    "timeStorageClassUpdated": Date().toISO8601(),
                                     "size": "14",
                                     "md5Hash": "stMQhvCYJU0yMUQ4qGPmHg==",
                                     "mediaLink": "https://www.googleapis.com/download/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o/b69d8159-e59f-4337-b03b-1c2df3ccfed9%2F9b77d4f0-43ea-4d70-9f65-e40808d1e429?generation=1486777096687000&alt=media",
@@ -2596,11 +2596,11 @@ class FileTestCase: StoreTestCase {
                                     ],
                                     "_filename" : "9b77d4f0-43ea-4d70-9f65-e40808d1e429",
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ],
                                     "_downloadURL" : "https://storage.googleapis.com/0b5b1cd673164e3185a2e75e815f5cfe/b69d8159-e59f-4337-b03b-1c2df3ccfed9/9b77d4f0-43ea-4d70-9f65-e40808d1e429?GoogleAccessId=558440376631@developer.gserviceaccount.com&Expires=1486780696&Signature=XW1B07b1srNI890hH0AUKiwroJJ8gl0DrqoDai1G45Txi2YzpJ1UAiDlrxeAMNWRNEYCTmJkuwkNXtdp8sXz7dYbQMK3x96vIQ6QRVVef590rvSbObhziBVBBdn%2B814PmTNEm6737awQNBTc%2FweK2SnDU6jFdbA5cCXqWs5USWk%3D",
-                                    "_expiresAt" : Date(timeIntervalSinceNow: TimeUnit.hour.timeInterval).toString()
+                                    "_expiresAt" : Date(timeIntervalSinceNow: TimeUnit.hour.timeInterval).toISO8601()
                                 ])
                             default:
                                 Swift.fatalError()
@@ -2680,8 +2680,8 @@ class FileTestCase: StoreTestCase {
                             "_id" : userId,
                             "username" : "aclShareWithAnotherUser_2AB4A3E2-793C-4E6F-B02D-BD4F714CE248",
                             "_kmd" : [
-                                "lmt" : Date().toString(),
-                                "ect" : Date().toString(),
+                                "lmt" : Date().toISO8601(),
+                                "ect" : Date().toISO8601(),
                                 "authtoken" : "f44b8f07-93ab-4c79-b413-f846ed7f34df.24+7RR+w8t845iG/dqkAJ3Vi6cU9ieO6tpg98vfVakY="
                             ],
                             "_acl" : [
@@ -2735,11 +2735,11 @@ class FileTestCase: StoreTestCase {
                                     ],
                                     "_filename" : "9b77d4f0-43ea-4d70-9f65-e40808d1e429",
                                     "_kmd" : [
-                                        "lmt" : Date().toString(),
-                                        "ect" : Date().toString()
+                                        "lmt" : Date().toISO8601(),
+                                        "ect" : Date().toISO8601()
                                     ],
                                     "_downloadURL" : "https://storage.googleapis.com/0b5b1cd673164e3185a2e75e815f5cfe/b69d8159-e59f-4337-b03b-1c2df3ccfed9/9b77d4f0-43ea-4d70-9f65-e40808d1e429?GoogleAccessId=558440376631@developer.gserviceaccount.com&Expires=1486780697&Signature=dS5zlMOJ3jgNZawRHd%2FZfCGx9eIYgARLDiDV3QcFP6%2BKshaxjbpAbc9NF2%2FkkDt3KxKPKfQKJoKJ%2FYvGJ2H3qH7vnrab7%2F1zx56roHawWnkexusZ1WxWJzmc3KNyGV9PeQrtyMzAoeZEjEmX38IMZrcat3Lzqo3rpzsSwONOiBI%3D",
-                                    "_expiresAt" : Date(timeIntervalSinceNow: TimeUnit.hour.timeInterval).toString()
+                                    "_expiresAt" : Date(timeIntervalSinceNow: TimeUnit.hour.timeInterval).toISO8601()
                                 ])
                             case 1:
                                 return HttpResponse(data: "secret message".data(using: .utf8))
@@ -2851,8 +2851,8 @@ class FileTestCase: StoreTestCase {
                     "mimeType" : "plain/txt",
                     "size" : 100,
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ],
                     "_downloadURL" : "https://storage.googleapis.com/file.txt"
                 ]
@@ -2902,11 +2902,11 @@ class FileTestCase: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ],
                         "_downloadURL" : "https://storage.googleapis.com/image.png",
-                        "_expiresAt" : Date(timeIntervalSinceNow: 3).toString()
+                        "_expiresAt" : Date(timeIntervalSinceNow: 3).toISO8601()
                     ]
                 ])
             }
@@ -2960,11 +2960,11 @@ class FileTestCase: StoreTestCase {
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ],
                     "_downloadURL" : "https://storage.googleapis.com/image.png",
-                    "_expiresAt" : Date(timeIntervalSinceNow: 3).toString()
+                    "_expiresAt" : Date(timeIntervalSinceNow: 3).toISO8601()
                 ])
             }
             defer {
@@ -3017,11 +3017,11 @@ class FileTestCase: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ],
                         "_downloadURL" : "https://storage.googleapis.com/image.png",
-                        "_expiresAt" : Date(timeIntervalSinceNow: 3).toString()
+                        "_expiresAt" : Date(timeIntervalSinceNow: 3).toISO8601()
                     ]
                 ])
             }
@@ -3127,11 +3127,11 @@ class FileTestCase: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
-                        "_expiresAt" : Date().toString(),
+                        "_expiresAt" : Date().toISO8601(),
                         "_requiredHeaders" : [
                         ]
                     ]
@@ -3207,11 +3207,11 @@ class FileTestCase: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
-                        "_expiresAt" : Date().toString(),
+                        "_expiresAt" : Date().toISO8601(),
                         "_requiredHeaders" : [
                         ]
                     ]
@@ -3285,11 +3285,11 @@ class FileTestCase: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
-                        "_expiresAt" : Date().toString(),
+                        "_expiresAt" : Date().toISO8601(),
                         "_requiredHeaders" : [
                         ]
                     ]

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -653,8 +653,8 @@ class KinveyTestCase: XCTestCase {
             Acl.Key.creator : self.client.activeUser!.userId
         ]
         json[Entity.EntityCodingKeys.metadata] = [
-            Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-            Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+            Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+            Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
         ]
         return json
     }

--- a/Kinvey/KinveyTests/MetadataTestCase.swift
+++ b/Kinvey/KinveyTests/MetadataTestCase.swift
@@ -20,8 +20,8 @@ class MetadataTestCase: XCTestCase {
         let ect = Date(timeIntervalSinceNow: 2)
         
         let json = [
-            Metadata.Key.lastModifiedTime: lmt.toString(),
-            Metadata.Key.entityCreationTime: ect.toString(),
+            Metadata.Key.lastModifiedTime: lmt.toISO8601(),
+            Metadata.Key.entityCreationTime: ect.toISO8601(),
             Metadata.Key.authtoken: authToken
         ]
         let metadata = Metadata(JSON: json)

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -815,8 +815,8 @@ class NetworkStoreTests: StoreTestCase {
                         "creator": self.client.activeUser?.userId
                     ]
                     json["_kmd"] = [
-                        "lmt": Date().toString(),
-                        "ect": Date().toString()
+                        "lmt": Date().toISO8601(),
+                        "ect": Date().toISO8601()
                     ]
                     json["_id"] = UUID().uuidString
                     mockData.append(json)
@@ -1641,8 +1641,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ],
             [
@@ -1653,8 +1653,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ]
         ]
@@ -1718,15 +1718,15 @@ class NetworkStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -1805,15 +1805,15 @@ class NetworkStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -1891,8 +1891,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ],
             [
@@ -1903,8 +1903,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ]
         ]
@@ -1973,8 +1973,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ],
             [
@@ -1985,8 +1985,8 @@ class NetworkStoreTests: StoreTestCase {
                     "creator": UUID().uuidString
                 ],
                 "_kmd": [
-                    "lmt": Date().toString(),
-                    "ect": Date().toString()
+                    "lmt": Date().toISO8601(),
+                    "ect": Date().toISO8601()
                 ]
             ]
         ]
@@ -3493,8 +3493,8 @@ class NetworkStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 }
@@ -3556,8 +3556,8 @@ class NetworkStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 }

--- a/Kinvey/KinveyTests/NoCacheTestCase.swift
+++ b/Kinvey/KinveyTests/NoCacheTestCase.swift
@@ -51,8 +51,8 @@ class NoCacheTestCase: XCTestCase {
                 "_id" : UUID().uuidString,
                 "name" : "Victor",
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ]
         ])

--- a/Kinvey/KinveyTests/StoreTestCase.swift
+++ b/Kinvey/KinveyTests/StoreTestCase.swift
@@ -33,13 +33,13 @@ class StoreTestCase: KinveyTestCase {
                     json = mockResponseHandler(json)
                 }
                 json["_id"] = json["_id"] ?? UUID().uuidString
-                json["date"] = Date().toString()
+                json["date"] = Date().toISO8601()
                 json["_acl"] = [
                     "creator" : UUID().uuidString
                 ]
                 json["_kmd"] = [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
                 return HttpResponse(json: json)
             }
@@ -89,8 +89,8 @@ class StoreTestCase: KinveyTestCase {
                     "creator" : UUID().uuidString
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
         }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -406,8 +406,8 @@ class SyncStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ],
                     [
@@ -418,8 +418,8 @@ class SyncStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 ])
@@ -552,8 +552,8 @@ class SyncStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ],
                     [
@@ -564,8 +564,8 @@ class SyncStoreTests: StoreTestCase {
                             "creator" : UUID().uuidString
                         ],
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString()
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601()
                         ]
                     ]
                 ])
@@ -798,8 +798,8 @@ class SyncStoreTests: StoreTestCase {
                         Acl.CodingKeys.creator.rawValue : self.client.activeUser!.userId
                     ]
                     json[Entity.EntityCodingKeys.metadata] = [
-                        Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-                        Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+                        Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+                        Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
                     ]
                     personMockJson.append(json)
                     return HttpResponse(statusCode: 201, json: json)
@@ -944,8 +944,8 @@ class SyncStoreTests: StoreTestCase {
                         Acl.CodingKeys.creator.rawValue : self.client.activeUser!.userId
                     ]
                     json[Entity.EntityCodingKeys.metadata] = [
-                        Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-                        Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+                        Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+                        Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
                     ]
                     personMockJson = json
                     return HttpResponse(statusCode: 201, json: json)
@@ -1085,8 +1085,8 @@ class SyncStoreTests: StoreTestCase {
                     Acl.CodingKeys.creator.rawValue : self.client.activeUser!.userId
                 ]
                 json[Entity.EntityCodingKeys.metadata] = [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
                 ]
                 return HttpResponse(statusCode: 201, json: json)
             }
@@ -1154,8 +1154,8 @@ class SyncStoreTests: StoreTestCase {
                     Acl.CodingKeys.creator.rawValue : self.client.activeUser!.userId
                 ]
                 json[Entity.EntityCodingKeys.metadata] = [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
                 ]
                 return HttpResponse(statusCode: 201, json: json)
             }
@@ -1208,8 +1208,8 @@ class SyncStoreTests: StoreTestCase {
                     Acl.CodingKeys.creator.rawValue : self.client.activeUser!.userId
                 ]
                 json[Entity.EntityCodingKeys.metadata] = [
-                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toString(),
-                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toString()
+                    Metadata.CodingKeys.lastModifiedTime.rawValue : Date().toISO8601(),
+                    Metadata.CodingKeys.entityCreationTime.rawValue : Date().toISO8601()
                 ]
                 return HttpResponse(statusCode: 201, json: json)
             }
@@ -2542,8 +2542,8 @@ class SyncStoreTests: StoreTestCase {
                         "creator" : self.client.activeUser!.userId
                     ]
                     json["_kmd"] = [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                     mockResponses.append(json)
                     return HttpResponse(statusCode: 201, json: json)
@@ -2963,8 +2963,8 @@ class SyncStoreTests: StoreTestCase {
                     "creator" : UUID().uuidString
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ]
         ])
@@ -3034,7 +3034,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -3083,7 +3083,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -3094,7 +3094,7 @@ class SyncStoreTests: StoreTestCase {
                                             "creator": "58450d87c077970e38a388ba"
                                         ],
                                         "_kmd": [
-                                            "lmt": Date().toString(),
+                                            "lmt": Date().toISO8601(),
                                             "ect": "2016-12-05T06:47:35.711Z"
                                         ]
                                     ]
@@ -3156,7 +3156,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -3209,7 +3209,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             "changed" : [
@@ -3220,7 +3220,7 @@ class SyncStoreTests: StoreTestCase {
                                         "creator": "58450d87c077970e38a388ba"
                                     ],
                                     "_kmd": [
-                                        "lmt": Date().toString(),
+                                        "lmt": Date().toISO8601(),
                                         "ect": "2016-12-05T06:47:35.711Z"
                                     ]
                                 ]
@@ -3272,7 +3272,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -3325,7 +3325,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             "changed" : [],
@@ -3375,7 +3375,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -3450,7 +3450,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             "changed" : [
@@ -3551,7 +3551,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -3606,7 +3606,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             "changed" : [
@@ -3759,7 +3759,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -3815,7 +3815,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person/_deltaset":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             "changed" : [
@@ -3966,7 +3966,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -4067,7 +4067,7 @@ class SyncStoreTests: StoreTestCase {
             case "/appdata/_kid_/Person":
                 return HttpResponse(
                     headerFields: [
-                        "X-Kinvey-Request-Start" : Date().toString()
+                        "X-Kinvey-Request-Start" : Date().toISO8601()
                     ],
                     json: [
                         [
@@ -4153,7 +4153,7 @@ class SyncStoreTests: StoreTestCase {
                 case "/appdata/_kid_/Person":
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -4215,7 +4215,7 @@ class SyncStoreTests: StoreTestCase {
                 case (1, "/appdata/_kid_/Person"?):
                     return HttpResponse(
                         headerFields: [
-                            "X-Kinvey-Request-Start" : Date().toString()
+                            "X-Kinvey-Request-Start" : Date().toISO8601()
                         ],
                         json: [
                             [
@@ -4293,7 +4293,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4373,7 +4373,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4457,7 +4457,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4513,7 +4513,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -4611,7 +4611,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4667,7 +4667,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -4753,7 +4753,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -4818,7 +4818,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -4893,7 +4893,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -4988,7 +4988,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5059,7 +5059,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -5154,7 +5154,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5225,7 +5225,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -5325,7 +5325,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5381,7 +5381,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -5457,7 +5457,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 [
@@ -5555,7 +5555,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5627,7 +5627,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5708,7 +5708,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5761,7 +5761,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -5855,7 +5855,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -5908,7 +5908,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -5991,7 +5991,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -6053,7 +6053,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -6124,7 +6124,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -6215,7 +6215,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -6282,7 +6282,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -6373,7 +6373,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -6440,7 +6440,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -6539,7 +6539,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -6592,7 +6592,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -6664,7 +6664,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 [
@@ -6772,7 +6772,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -6842,7 +6842,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [
@@ -6922,7 +6922,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -7021,7 +7021,7 @@ class SyncStoreTests: StoreTestCase {
                         ]
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: json
                         )
@@ -7097,7 +7097,7 @@ class SyncStoreTests: StoreTestCase {
                     case "/appdata/_kid_/Person/_deltaset":
                         return HttpResponse(
                             headerFields: [
-                                "X-Kinvey-Request-Start" : Date().toString()
+                                "X-Kinvey-Request-Start" : Date().toISO8601()
                             ],
                             json: [
                                 "changed" : [],
@@ -7168,8 +7168,8 @@ class SyncStoreTests: StoreTestCase {
                         "creator" : UUID().uuidString
                     ]
                     entity["_kmd"] = [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString()
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601()
                     ]
                     entities.append(entity)
                 }
@@ -7335,8 +7335,8 @@ class SyncStoreTests: StoreTestCase {
                     "creator" : self.client.activeUser!.userId
                 ],
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString()
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601()
                 ]
             ])
         }
@@ -7349,17 +7349,17 @@ class SyncStoreTests: StoreTestCase {
                     let skip = Int(skipString)
                 {
                     return HttpResponse(
-                        headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                        headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                         json: Array(json[skip...])
                     )
                 }
                 return HttpResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: json
                 )
             case "/appdata/_kid_/Person/_deltaset":
                 return HttpResponse(
-                    headerFields: ["X-Kinvey-Request-Start" : Date().toString()],
+                    headerFields: ["X-Kinvey-Request-Start" : Date().toISO8601()],
                     json: [
                         "changed" : [],
                         "deleted" : []
@@ -7669,15 +7669,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -7793,15 +7793,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -7939,15 +7939,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -8022,15 +8022,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -8105,15 +8105,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -8189,15 +8189,15 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         let id2 = UUID().uuidString
         let name2 = UUID().uuidString
         let age2 = Int(arc4random())
         let creator2 = UUID().uuidString
-        let lmt2 = Date().toString()
-        let ect2 = Date().toString()
+        let lmt2 = Date().toISO8601()
+        let ect2 = Date().toISO8601()
         
         let mockObjs: [[String : Any]] = [
             [
@@ -8272,8 +8272,8 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         var count = 0
         mockResponse { request in
@@ -8349,8 +8349,8 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         var count = 0
         mockResponse { request in
@@ -8426,8 +8426,8 @@ class SyncStoreTests: StoreTestCase {
         let name1 = UUID().uuidString
         let age1 = Int(arc4random())
         let creator1 = UUID().uuidString
-        let lmt1 = Date().toString()
-        let ect1 = Date().toString()
+        let lmt1 = Date().toISO8601()
+        let ect1 = Date().toISO8601()
         
         var count = 0
         mockResponse { request in

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -351,8 +351,8 @@ class UserTests: KinveyTestCase {
             "_id" : userId,
             "username" : username,
             "_kmd": [
-                "lmt" : Date().toString(),
-                "ect" : Date().toString(),
+                "lmt" : Date().toISO8601(),
+                "ect" : Date().toISO8601(),
                 "authtoken" : UUID().uuidString
             ],
             "_acl" : [
@@ -3453,8 +3453,8 @@ class UserTests: KinveyTestCase {
                     "password" : UUID().uuidString,
                     "username" : UUID().uuidString,
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString(),
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601(),
                         "authtoken" : newAuthToken
                     ],
                     "_id" : userId,
@@ -3749,8 +3749,8 @@ class UserTests: KinveyTestCase {
                         "password" : UUID().uuidString,
                         "username" : UUID().uuidString,
                         "_kmd" : [
-                            "lmt" : Date().toString(),
-                            "ect" : Date().toString(),
+                            "lmt" : Date().toISO8601(),
+                            "ect" : Date().toISO8601(),
                             "authtoken" : UUID().uuidString
                         ],
                         "_id" : userId,
@@ -3770,8 +3770,8 @@ class UserTests: KinveyTestCase {
                                 "creator": UUID().uuidString
                             ],
                             "_kmd": [
-                                "lmt": Date().toString(),
-                                "ect": Date().toString()
+                                "lmt": Date().toISO8601(),
+                                "ect": Date().toISO8601()
                             ]
                         ]
                     ])
@@ -4260,8 +4260,8 @@ extension UserTests {
                 "_id" : userId,
                 "username" : UUID().uuidString,
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString(),
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601(),
                     "authtoken" : UUID().uuidString
                 ],
                 "_acl" : [
@@ -4482,8 +4482,8 @@ extension UserTests {
                 "_id" : userId,
                 "username" : UUID().uuidString,
                 "_kmd" : [
-                    "lmt" : Date().toString(),
-                    "ect" : Date().toString(),
+                    "lmt" : Date().toISO8601(),
+                    "ect" : Date().toISO8601(),
                     "authtoken" : UUID().uuidString
                 ],
                 "_acl" : [
@@ -4996,8 +4996,8 @@ extension UserTests {
                     "_id" : UUID().uuidString,
                     "username" : "test",
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString(),
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601(),
                         "authtoken" : UUID().uuidString
                     ],
                     "_acl" : [
@@ -5074,8 +5074,8 @@ extension UserTests {
                     "_id" : UUID().uuidString,
                     "username" : "test",
                     "_kmd" : [
-                        "lmt" : Date().toString(),
-                        "ect" : Date().toString(),
+                        "lmt" : Date().toISO8601(),
+                        "ect" : Date().toISO8601(),
                         "authtoken" : UUID().uuidString
                     ],
                     "_acl" : [
@@ -5344,8 +5344,8 @@ extension UserTests {
                         "creator": client.activeUser?.userId
                     ],
                     "_kmd": [
-                        "lmt": Date().toString(),
-                        "ect": Date().toString()
+                        "lmt": Date().toISO8601(),
+                        "ect": Date().toISO8601()
                     ]
                 ]
             ])


### PR DESCRIPTION
#### Description

Be able to store dates as ISO 8601 strings

#### Changes

- Users using `Codable` don't have an easy way to store dates as before

#### Tests

- No need for new unit tests
