### PR TITLE
MLIBZ-2777: Allowing perform queries using KeyPath syntax

### DIFF
--- a/Kinvey/Kinvey/Query.swift
+++ b/Kinvey/Kinvey/Query.swift
@@ -11,6 +11,18 @@ import Foundation
     import MapKit
 #endif
 
+#if canImport(os)
+    import os
+#endif
+
+extension NSPredicate {
+    
+    internal var asString: String {
+        return String(describing: self)
+    }
+    
+}
+
 /// Class that represents a query including filters and sorts.
 public final class Query: NSObject, BuilderType {
     
@@ -22,11 +34,24 @@ public final class Query: NSObject, BuilderType {
     }
     
     /// `NSPredicate` used to filter records.
-    public var predicate: NSPredicate?
-    
-    internal var predicateAsString: String? {
-        return predicate.map({ String(describing: $0) })
+    public var predicate: NSPredicate? {
+        get {
+            guard let predicateKind = predicateKind else {
+                return nil
+            }
+            switch predicateKind {
+            case .predicate(let predicate):
+                return predicate
+            case .booleanExpression(let booleanExpression):
+                return booleanExpression.expression.predicate
+            }
+        }
+        set {
+            predicateKind = newValue.predicateKind
+        }
     }
+    
+    private var predicateKind: PredicateKind?
     
     /// Array of `NSSortDescriptor`s used to sort records.
     public var sortDescriptors: [NSSortDescriptor]?
@@ -143,12 +168,18 @@ public final class Query: NSObject, BuilderType {
     }
     
     fileprivate var queryStringEncoded: String? {
-        guard let predicate = predicate else {
+        guard let predicateKind = predicateKind else {
             return emptyPredicateMustReturnNil ? nil : "{}"
         }
         
-        let translatedPredicate = translate(predicate: predicate)
-        let queryObj = translatedPredicate.mongoDBQuery!
+        let queryObj: [String : Any]
+        switch predicateKind {
+        case .predicate(let predicate):
+            let translatedPredicate = translate(predicate: predicate)
+            queryObj = translatedPredicate.mongoDBQuery!
+        case .booleanExpression(let booleanExpression):
+            queryObj = booleanExpression.expression.mongoDBQuery!
+        }
         
         let data = try! JSONSerialization.data(withJSONObject: queryObj)
         let queryStr = String(data: data, encoding: String.Encoding.utf8)!
@@ -199,10 +230,31 @@ public final class Query: NSObject, BuilderType {
         fields: Set<String>? = nil,
         persistableType: Persistable.Type? = nil
     ) {
-        self.predicate = predicate
+        self.predicateKind = predicate.predicateKind
         self.sortDescriptors = sortDescriptors
         self.fields = fields
         self.persistableType = persistableType
+    }
+    
+    public var booleanExpression: BooleanExpression? {
+        get {
+            guard let predicateKind = predicateKind else {
+                return nil
+            }
+            switch predicateKind {
+            case .booleanExpression(let booleanExpression):
+                return booleanExpression
+            case .predicate:
+                return nil
+            }
+        }
+        set {
+            predicateKind = newValue.predicateKind
+        }
+    }
+    
+    public init(_ booleanExpression: BooleanExpression) {
+        self.predicateKind = .booleanExpression(booleanExpression)
     }
     
     convenience init(query: Query, persistableType: Persistable.Type) {
@@ -290,19 +342,60 @@ public final class Query: NSObject, BuilderType {
     }
     
     /// Adds ascending properties to be sorted.
-    public func ascending(_ properties: String...) {
+    @discardableResult
+    public func ascending(_ properties: String...) -> Query {
         for property in properties {
             addSort(property, ascending: true)
         }
+        return self
     }
     
     /// Adds descending properties to be sorted.
-    public func descending(_ properties: String...) {
+    @discardableResult
+    public func descending(_ properties: String...) -> Query {
         for property in properties {
             addSort(property, ascending: false)
         }
+        return self
+    }
+    
+    @discardableResult
+    public func sort<Root, Value>(_ keyPath: KeyPath<Root, Value>, ascending: Bool) -> Query {
+        sortLock.lock()
+        if sortDescriptors == nil {
+            sortDescriptors = []
+        }
+        sortLock.unlock()
+        sortDescriptors!.append(NSSortDescriptor(key: keyPath.name, ascending: ascending))
+        return self
+    }
+    
+    /// Adds ascending properties to be sorted.
+    @discardableResult
+    public func ascending<Root, Value>(_ keyPaths: KeyPath<Root, Value>...) -> Query {
+        for keyPath in keyPaths {
+            sort(keyPath, ascending: true)
+        }
+        return self
+    }
+    
+    /// Adds ascending properties to be sorted.
+    @discardableResult
+    public func descending<Root, Value>(_ keyPaths: KeyPath<Root, Value>...) -> Query {
+        for keyPath in keyPaths {
+            sort(keyPath, ascending: false)
+        }
+        return self
     }
 
+}
+
+extension KeyPath {
+    
+    internal var name: String {
+        return NSExpression(forKeyPath: self).keyPath
+    }
+    
 }
 
 @available(*, deprecated: 3.18.0, message: "Please use Swift.Codable instead")
@@ -311,6 +404,768 @@ extension Query: Mappable {
     public func mapping(map: Map) {
         if map.mappingType == .toJSON, let predicate = predicate {
             predicate.mapping(map: map)
+        }
+    }
+    
+}
+
+public indirect enum Expression {
+    
+    public typealias ExpressionProducer = () -> Expression
+    
+    case column(String)
+    case and(lhs: Expression, rhs: Expression)
+    case or(lhs: Expression, rhs: Expression)
+    case equality(lhs: Expression, rhs: Expression)
+    case inequality(lhs: Expression, rhs: Expression)
+    case not(rhs: Expression)
+    case lessThan(lhs: Expression, rhs: Expression)
+    case lessThanEqual(lhs: Expression, rhs: Expression)
+    case greaterThan(lhs: Expression, rhs: Expression)
+    case greaterThanEqual(lhs: Expression, rhs: Expression)
+    case `in`(lhs: Expression, rhs: [Expression])
+    case like(lhs: Expression, wild1: Bool, String, wild2: Bool)
+    case geoIn(lhs: Expression, rhs: Expression)
+    case lazy(ExpressionProducer)
+    case keyPath(AnyKeyPath, NSExpression)
+    
+    case integer(Int)
+    case uinteger(UInt)
+    case integer64(Int64)
+    case uinteger64(UInt64)
+    case integer32(Int32)
+    case uinteger32(UInt32)
+    case integer16(Int16)
+    case uinteger16(UInt16)
+    case integer8(Int8)
+    case uinteger8(UInt8)
+    
+    case double(Double)
+    case float(Float)
+    case string(String)
+    case blob([UInt8])
+    case sblob([Int8])
+    case bool(Bool)
+    case uuid(UUID)
+    case date(Date)
+    case url(URL)
+    case circle(MKCircle)
+    case polygon(MKPolygon)
+    case null
+    
+}
+
+// MARK: - Mongo DB Query
+
+extension Expression {
+    
+    var mongoDBQuery: [String : Any]? {
+        return transform(expression: self)
+    }
+    
+    var keyPath: String? {
+        switch self {
+        case .keyPath(_, let expression):
+            return expression.keyPath
+        default:
+            return nil
+        }
+    }
+    
+    var value: Any? {
+        switch self {
+        case .integer(let value as Any),
+             .uinteger(let value as Any),
+             .integer64(let value as Any),
+             .uinteger64(let value as Any),
+             .integer32(let value as Any),
+             .uinteger32(let value as Any),
+             .integer16(let value as Any),
+             .uinteger16(let value as Any),
+             .integer8(let value as Any),
+             .uinteger8(let value as Any),
+             .double(let value as Any),
+             .float(let value as Any),
+             .string(let value as Any),
+             .blob(let value as Any),
+             .sblob(let value as Any),
+             .bool(let value as Any),
+             .uuid(let value as Any),
+             .date(let value as Any),
+             .url(let value as Any),
+             .circle(let value as Any),
+             .polygon(let value as Any):
+            return value
+        case .null:
+            return NSNull()
+        default:
+            return nil
+        }
+    }
+    
+    private func transform(lhs: Expression, operator: MongoDBOperator, rhs: Expression, optimize: Bool) -> [String : Any]? {
+        let keyPath = lhs.keyPath!
+        let value = rhs.value!
+        switch (`operator`, optimize) {
+        case (MongoDBOperator.equalTo, true):
+            return [keyPath : value]
+        default:
+            return [keyPath : [`operator`.rawValue : value]]
+        }
+    }
+    
+    private func transform(expression: Expression, optimize: Bool = true) -> [String : Any]? {
+        switch expression {
+        case .equality(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .equalTo, rhs: rhs, optimize: optimize)
+        case .inequality(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .notEqualTo, rhs: rhs, optimize: optimize)
+        case .greaterThan(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .greaterThan, rhs: rhs, optimize: optimize)
+        case .greaterThanEqual(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .greaterThanOrEqualTo, rhs: rhs, optimize: optimize)
+        case .lessThan(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .lessThan, rhs: rhs, optimize: optimize)
+        case .lessThanEqual(let lhs, let rhs):
+            return transform(lhs: lhs, operator: .lessThanOrEqualTo, rhs: rhs, optimize: optimize)
+        case .and(let lhs, let rhs):
+            let expressions = [
+                transform(expression: lhs, optimize: optimize),
+                transform(expression: rhs, optimize: optimize)
+            ].compactMap { $0 }
+            if optimize, expressions.count <= 1 {
+                return expressions.first
+            }
+            if optimize,
+                let sequence = Optional(expressions.filter({ $0.count == 1 }).compactMap({ $0.first })),
+                expressions.count == Set(sequence.map{ $0.key }).count
+            {
+                return [String : Any](uniqueKeysWithValues: sequence)
+            }
+            return [MongoDBOperator.and.rawValue : expressions]
+        case .or(let lhs, let rhs):
+            return [
+                MongoDBOperator.or.rawValue : [
+                    transform(expression: lhs, optimize: optimize),
+                    transform(expression: rhs, optimize: optimize)
+                ]
+            ]
+        case .not(let rhs):
+            return [MongoDBOperator.not.rawValue : [transform(expression:rhs, optimize: optimize)]]
+        case .like(let lhs, let wild1, let value, let wild2):
+            let keyPath: String
+            switch lhs {
+            case .keyPath(_, let expression):
+                keyPath = expression.keyPath
+            default:
+                return nil
+            }
+            let regexValue: String
+            switch (wild1, wild2) {
+            case (true, true):
+                regexValue = ".*\(value).*"
+            case (false, true):
+                regexValue = ".*\(value)"
+            case (true, false):
+                regexValue = "^\(value)"
+            default:
+                regexValue = value
+            }
+            return [
+                keyPath : [
+                    MongoDBOperator.matches.rawValue : regexValue
+                ]
+            ]
+        case .in(let lhs, let rhs):
+            let keyPath: String
+            switch lhs {
+            case .keyPath(_, let expression):
+                keyPath = expression.keyPath
+            default:
+                return nil
+            }
+            let values = rhs.map { $0.value }
+            return [
+                keyPath : [
+                    MongoDBOperator.in.rawValue : values
+                ]
+            ]
+        case .geoIn(let lhs, let rhs):
+            let keyPath: String
+            switch lhs {
+            case .keyPath(_, let expression):
+                keyPath = expression.keyPath
+            default:
+                return nil
+            }
+            return [
+                keyPath : [
+                    MongoDBOperator.geoIn.rawValue : transform(expression: rhs, optimize: optimize)
+                ]
+            ]
+        case .circle(let circle):
+            return [
+                "$centerSphere" : [
+                    [
+                        circle.coordinate.longitude,
+                        circle.coordinate.latitude
+                    ],
+                    circle.radius / 6371000.0
+                ]
+            ]
+        case .polygon(let polygon):
+            let pointCount = polygon.pointCount
+            var coordinates = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
+            polygon.getCoordinates(&coordinates, range: NSRange(location: 0, length: pointCount))
+            let coordinatesArray = coordinates.map { [$0.longitude, $0.latitude] }
+            return [
+                "$polygon" : coordinatesArray
+            ]
+        default:
+            return [:]
+        }
+    }
+    
+}
+
+// MARK: - Expression -> Predicate
+
+extension Expression {
+    
+    var predicate: NSPredicate? {
+        return transform(expression: self)
+    }
+    
+    var expression: NSExpression? {
+        switch self {
+        case .keyPath(_, let expression):
+            return expression
+        case .integer(let value as Any),
+             .uinteger(let value as Any),
+             .integer64(let value as Any),
+             .uinteger64(let value as Any),
+             .integer32(let value as Any),
+             .uinteger32(let value as Any),
+             .integer16(let value as Any),
+             .uinteger16(let value as Any),
+             .integer8(let value as Any),
+             .uinteger8(let value as Any),
+             .double(let value as Any),
+             .float(let value as Any),
+             .string(let value as Any),
+             .blob(let value as Any),
+             .sblob(let value as Any),
+             .bool(let value as Any),
+             .uuid(let value as Any),
+             .date(let value as Any),
+             .url(let value as Any),
+             .circle(let value as Any),
+             .polygon(let value as Any):
+            return NSExpression(forConstantValue: value)
+        case .null:
+            return NSExpression(forConstantValue: nil)
+        default:
+            return nil
+        }
+    }
+    
+    private func transform(expression: Expression) -> NSPredicate? {
+        switch expression {
+        case .equality(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .equalTo)
+        case .inequality(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .notEqualTo)
+        case .greaterThan(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .greaterThan)
+        case .greaterThanEqual(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .greaterThanOrEqualTo)
+        case .lessThan(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .lessThan)
+        case .lessThanEqual(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: rhs.expression!, type: .lessThanOrEqualTo)
+        case .and(let lhs, let rhs):
+            return NSCompoundPredicate(andPredicateWithSubpredicates: [lhs.predicate!, rhs.predicate!])
+        case .or(let lhs, let rhs):
+            return NSCompoundPredicate(orPredicateWithSubpredicates: [lhs.predicate!, rhs.predicate!])
+        case .not(let rhs):
+            return NSCompoundPredicate(notPredicateWithSubpredicate: rhs.predicate!)
+        case .like(let lhs, let wild1, let rhs, let wild2):
+            let type: NSComparisonPredicate.Operator
+            switch (wild1, wild2) {
+            case (true, true):
+                type = .contains
+            case (false, true):
+                type = .endsWith
+            case (true, false):
+                type = .beginsWith
+            default:
+                return nil
+            }
+            return transform(lhs: lhs.expression!, rhs: NSExpression(forConstantValue: rhs), type: type)
+        case .`in`(let lhs, let rhs):
+            return transform(lhs: lhs.expression!, rhs: NSExpression(forConstantValue: rhs.map { $0.expression!.constantValue }), type: .in)
+        default:
+            return nil
+        }
+    }
+    
+    private func transform(
+        lhs: NSExpression,
+        rhs: NSExpression,
+        modifier: NSComparisonPredicate.Modifier = .direct,
+        type: NSComparisonPredicate.Operator,
+        options: NSComparisonPredicate.Options = []
+    ) -> NSComparisonPredicate {
+        return NSComparisonPredicate(
+            leftExpression: lhs,
+            rightExpression: rhs,
+            modifier: modifier,
+            type: type,
+            options: options
+        )
+    }
+    
+}
+
+// MARK: - BooleanExpression
+
+public protocol BooleanExpression {
+    
+    var expression: Expression { get }
+    
+}
+
+struct BooleanExpressionWrapper: BooleanExpression {
+    
+    let expression: Expression
+    
+    init(_ e: Expression) {
+        expression = e
+    }
+    
+}
+
+enum PredicateKind {
+    
+    case predicate(NSPredicate)
+    case booleanExpression(BooleanExpression)
+    
+}
+
+// MARK: - == Operator
+
+public func == <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.equality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func == <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.equality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func == <Root, Value: GeoValueExpressionType>(lhs: KeyPath<Root, GeoPoint>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.geoIn(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func == <Root, Value: GeoValueExpressionType>(lhs: KeyPath<Root, GeoPoint?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.geoIn(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - != Operator
+
+public func != <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.inequality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func != <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.inequality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - <> Operator
+
+infix operator <>: ComparisonPrecedence
+
+public func <> <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.inequality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func <> <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.inequality(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - < Operator
+
+public func < <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.lessThan(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func < <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.lessThan(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - <= Operator
+
+public func <= <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.lessThanEqual(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func <= <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.lessThanEqual(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - > Operator
+
+public func > <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.greaterThan(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func > <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.greaterThan(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - >= Operator
+
+public func >= <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.greaterThanEqual(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+public func >= <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: Value) -> BooleanExpression {
+    return BooleanExpressionWrapper(.greaterThanEqual(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - && Operator
+
+public func && (lhs: BooleanExpression, rhs: BooleanExpression) -> BooleanExpression {
+    return BooleanExpressionWrapper(.and(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - || Operator
+
+public func || (lhs: BooleanExpression, rhs: BooleanExpression) -> BooleanExpression {
+    return BooleanExpressionWrapper(.or(lhs: lhs.expression, rhs: rhs.expression))
+}
+
+// MARK: - ! Operator
+
+public prefix func ! (rhs: BooleanExpression) -> BooleanExpression {
+    return BooleanExpressionWrapper(.not(rhs: rhs.expression))
+}
+
+// MARK: - %=% Operator LIKE CONTAINS
+
+infix operator %=%: ComparisonPrecedence // LIKE %v% . string or regexp or in array
+
+public func %=% <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: true, rhs, wild2: true))
+}
+
+public func %=% <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: true, rhs, wild2: true))
+}
+
+// MARK: - =% Operator LIKE BEGINS WITH
+
+infix operator =%: ComparisonPrecedence // LIKE v% . string
+
+public func =% <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: true, rhs, wild2: false))
+}
+
+public func =% <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: true, rhs, wild2: false))
+}
+
+// MARK: - %= Operator LIKE ENDS WITH
+
+public func %= <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: false, rhs, wild2: true))
+}
+
+public func %= <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return BooleanExpressionWrapper(.like(lhs: lhs.expression, wild1: false, rhs, wild2: true))
+}
+
+// MARK: - !~ Operator NOT LIKE
+
+infix operator %!=%: ComparisonPrecedence // NOT LIKE %v% . string or regexp or array
+
+public func %!=% <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return !(lhs %=% rhs)
+}
+
+public func %!=% <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return !(lhs %=% rhs)
+}
+
+infix operator !=%: ComparisonPrecedence // NOT LIKE v% . string
+
+public func !=% <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return !(lhs =% rhs)
+}
+
+public func !=% <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return !(lhs =% rhs)
+}
+
+infix operator %!=: ComparisonPrecedence // NOT LIKE %v . string
+
+public func %!= <Root>(lhs: KeyPath<Root, String>, rhs: String) -> BooleanExpression {
+    return !(lhs %= rhs)
+}
+
+public func %!= <Root>(lhs: KeyPath<Root, String?>, rhs: String) -> BooleanExpression {
+    return !(lhs %= rhs)
+}
+
+// MARK: - ~ Operator IN
+
+infix operator ~: ComparisonPrecedence // IN, matches
+
+public func ~ <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: [Value]) -> BooleanExpression {
+    return BooleanExpressionWrapper(.in(lhs: lhs.expression, rhs: rhs.map { $0.expression }))
+}
+
+public func ~ <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: [Value]) -> BooleanExpression {
+    return BooleanExpressionWrapper(.in(lhs: lhs.expression, rhs: rhs.map { $0.expression }))
+}
+
+// MARK: - !~ Operator NOT IN
+
+infix operator !~: ComparisonPrecedence // NOT IN, matches
+
+public func !~ <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value>, rhs: [Value]) -> BooleanExpression {
+    return !(lhs ~ rhs)
+}
+
+public func !~ <Root, Value: ValueExpressionType>(lhs: KeyPath<Root, Value?>, rhs: [Value]) -> BooleanExpression {
+    return !(lhs ~ rhs)
+}
+
+// MARK: - Expression Types
+
+public protocol ExpressionType {
+    
+    var expression: Expression { get }
+    
+}
+
+extension KeyPath: ExpressionType {
+    
+    public var expression: Expression {
+        return .keyPath(self, NSExpression(forKeyPath: self))
+    }
+    
+}
+
+public protocol ValueExpressionType: ExpressionType {
+}
+
+public protocol GeoValueExpressionType: ExpressionType {
+}
+
+extension Int: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .integer(self)
+    }
+    
+}
+
+extension UInt: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uinteger(self)
+    }
+    
+}
+
+extension Int64: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .integer64(self)
+    }
+    
+}
+
+extension UInt64: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uinteger64(self)
+    }
+    
+}
+
+extension Int32: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .integer32(self)
+    }
+    
+}
+
+extension UInt32: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uinteger32(self)
+    }
+    
+}
+
+extension Int16: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .integer16(self)
+    }
+    
+}
+
+extension UInt16: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uinteger16(self)
+    }
+    
+}
+
+extension Int8: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .integer8(self)
+    }
+    
+}
+
+extension UInt8: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uinteger8(self)
+    }
+    
+}
+
+extension Double: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .double(self)
+    }
+    
+}
+
+extension Float: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .float(self)
+    }
+    
+}
+
+extension String: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .string(self)
+    }
+    
+}
+
+extension Array: ValueExpressionType, ExpressionType where Element == UInt8 {
+    
+    public var expression: Expression {
+        return .blob(self)
+    }
+    
+}
+
+extension Array /*: ValueExpressionType, ExpressionType */ where Element == Int8 {
+    
+    public var expression: Expression {
+        return .sblob(self)
+    }
+    
+}
+
+extension Bool: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .bool(self)
+    }
+    
+}
+
+extension UUID: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .uuid(self)
+    }
+    
+}
+
+extension Date: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .date(self)
+    }
+    
+}
+
+extension URL: ValueExpressionType {
+    
+    public var expression: Expression {
+        return .url(self)
+    }
+    
+}
+
+extension MKCircle: GeoValueExpressionType {
+    
+    public var expression: Expression {
+        return .circle(self)
+    }
+    
+}
+
+extension MKPolygon: GeoValueExpressionType {
+    
+    public var expression: Expression {
+        return .polygon(self)
+    }
+    
+}
+
+// MARK: - Optional Expression
+
+extension Optional where Wrapped: ExpressionType {
+    
+    public var expression: Expression {
+        if let value = self {
+            return value.expression
+        }
+        return .null
+    }
+    
+}
+
+// MARK: - Optional PredicateKind
+
+extension Optional where Wrapped == BooleanExpression {
+    
+    var predicateKind: PredicateKind? {
+        switch self {
+        case .some(let wrapped):
+            return .booleanExpression(wrapped)
+        default:
+            return nil
+        }
+    }
+    
+}
+
+extension Optional where Wrapped == NSPredicate {
+    
+    var predicateKind: PredicateKind? {
+        switch self {
+        case .some(let wrapped):
+            return .predicate(wrapped)
+        default:
+            return nil
         }
     }
     

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -592,7 +592,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
         }
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(format: "collectionName == %@", self.collectionName),
-            query.predicateAsString.map({ NSPredicate(format: "query == %@", $0) }) ?? NSPredicate(format: "query == nil"),
+            (query.predicate?.asString).map({ NSPredicate(format: "query == %@", $0) }) ?? NSPredicate(format: "query == nil"),
             query.fieldsAsString.map({ NSPredicate(format: "fields == %@", $0) }) ?? NSPredicate(format: "fields == nil")
         ])
         results = results.filter(predicate)
@@ -906,7 +906,7 @@ extension RealmCache: DynamicCacheType {
         let block: (String) -> Void = { entityTypeCollectionName in
             let realmSyncQuery = _QueryCache()
             realmSyncQuery.collectionName = entityTypeCollectionName
-            realmSyncQuery.query = syncQuery.query.predicateAsString
+            realmSyncQuery.query = syncQuery.query.predicate?.asString
             realmSyncQuery.fields = syncQuery.query.fieldsAsString
             realmSyncQuery.lastSync = syncQuery.lastSync
             realmSyncQuery.generateKey()

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -224,7 +224,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         }
         
         let query = Query(format: "\(try! Person.aclProperty() ?? Person.EntityCodingKeys.acl.rawValue).creator == %@", activeUser.userId)
-        query.ascending("name")
+        query.ascending(\Person.name)
         
         do {
             weak var expectationRead = expectation(description: "Read")
@@ -424,7 +424,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         }
         
         let query = Query(format: "\(try! Person.aclProperty() ?? Person.EntityCodingKeys.acl.rawValue).creator == %@", activeUser.userId)
-        query.ascending("name")
+        query.ascending(\Person.name)
         
         do {
             weak var expectationRead = expectation(description: "Read")
@@ -595,7 +595,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         }
         
         let query = Query(format: "\(try! Person.aclProperty() ?? Person.EntityCodingKeys.acl.rawValue).creator == %@", activeUser.userId)
-        query.ascending("name")
+        query.ascending(\Person.name)
         
         do {
             weak var expectationRead = expectation(description: "Read")
@@ -759,7 +759,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         let store = try! DataStore<Person>.collection(.sync)
         
         let query = Query(format: "\(try! Person.aclProperty() ?? Person.EntityCodingKeys.acl.rawValue).creator == %@", activeUser.userId)
-        query.ascending("name")
+        query.ascending(\Person.name)
         
         do {
             weak var expectationRead = expectation(description: "Read")
@@ -1068,7 +1068,7 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         let store = try! DataStore<Person>.collection(.sync)
         
         let query = Query(format: "\(try! Person.aclProperty() ?? Person.EntityCodingKeys.acl.rawValue).creator == %@", activeUser.userId)
-        query.ascending("name")
+        query.ascending(\Person.name)
         
         do {
             weak var expectationRead = self.expectation(description: "Read")

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -895,7 +895,7 @@ class NetworkStoreTests: StoreTestCase {
                 $0.predicate = NSPredicate(format: "acl.creator == %@", user.userId)
                 $0.skip = skip
                 $0.limit = limit
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceNetwork)) {

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -52,6 +52,8 @@ class QueryTest: XCTestCase {
     }
     
     func testQueryEq() {
+        XCTAssertEqual(encodeQuery(Query(\Person.age == 30)), "query=\(encodeURL(["age" : 30]))")
+        XCTAssertEqual(Query(\Person.age == 30).predicate, NSPredicate(format: "age == %@", argumentArray: [30]))
         XCTAssertEqual(encodeQuery(Query(format: "age == %@", 30)), "query=\(encodeURL(["age" : 30]))")
         XCTAssertEqual(encodeQuery(Query(format: "age = %@", 30)), "query=\(encodeURL(["age" : 30]))")
         XCTAssertEqual(encodeQuery(Query(format: "obj._id == %@", 30)), "query=\(encodeURL(["obj._id" : 30]))")
@@ -103,6 +105,8 @@ class QueryTest: XCTestCase {
     
     func testQueryGt() {
         XCTAssertEqual(encodeQuery(Query(format: "age > %@", 30)), "query=\(encodeURL(["age" : ["$gt" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age > 30)), "query=\(encodeURL(["age" : ["$gt" : 30]]))")
+        XCTAssertEqual(Query(\Person.age > 30).predicate, NSPredicate(format: "age > %@", argumentArray: [30]))
     }
     
     func testQueryNotGt() {
@@ -111,6 +115,8 @@ class QueryTest: XCTestCase {
     
     func testQueryGte() {
         XCTAssertEqual(encodeQuery(Query(format: "age >= %@", 30)), "query=\(encodeURL(["age" : ["$gte" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age >= 30)), "query=\(encodeURL(["age" : ["$gte" : 30]]))")
+        XCTAssertEqual(Query(\Person.age >= 30).predicate, NSPredicate(format: "age >= %@", argumentArray: [30]))
     }
     
     func testQueryNotGte() {
@@ -119,35 +125,56 @@ class QueryTest: XCTestCase {
     
     func testQueryLt() {
         XCTAssertEqual(encodeQuery(Query(format: "age < %@", 30)), "query=\(encodeURL(["age" : ["$lt" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age < 30)), "query=\(encodeURL(["age" : ["$lt" : 30]]))")
+        XCTAssertEqual(Query(\Person.age < 30).predicate, NSPredicate(format: "age < %@", argumentArray: [30]))
     }
     
     func testQueryLte() {
         XCTAssertEqual(encodeQuery(Query(format: "age <= %@", 30)), "query=\(encodeURL(["age" : ["$lte" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age <= 30)), "query=\(encodeURL(["age" : ["$lte" : 30]]))")
+        XCTAssertEqual(Query(\Person.age <= 30).predicate, NSPredicate(format: "age <= %@", argumentArray: [30]))
     }
     
     func testQueryNe() {
         XCTAssertEqual(encodeQuery(Query(format: "age != %@", 30)), "query=\(encodeURL(["age" : ["$ne" : 30]]))")
         XCTAssertEqual(encodeQuery(Query(format: "age <> %@", 30)), "query=\(encodeURL(["age" : ["$ne" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age != 30)), "query=\(encodeURL(["age" : ["$ne" : 30]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age <> 30)), "query=\(encodeURL(["age" : ["$ne" : 30]]))")
+        XCTAssertEqual(Query(\Person.age != 30).predicate, NSPredicate(format: "age != %@", argumentArray: [30]))
+        XCTAssertEqual(Query(\Person.age <> 30).predicate, NSPredicate(format: "age != %@", argumentArray: [30]))
     }
     
-    func testQueryIn() {
+    class Rainbow {
+        @objc var colors: String?
+    }
+    
+    func testQueryIn() {   
         XCTAssertEqual(encodeQuery(Query(format: "colors IN %@", ["orange", "black"])), "query=\(encodeURL(["colors" : ["$in" : ["orange", "black"]]]))")
+        XCTAssertEqual(encodeQuery(Query(\Rainbow.colors ~ ["orange", "black"])), "query=\(encodeURL(["colors" : ["$in" : ["orange", "black"]]]))")
+        XCTAssertEqual(Query(\Rainbow.colors ~ ["orange", "black"]).predicate, NSPredicate(format: "colors IN %@", ["orange", "black"]))
     }
     
     func testQueryOr() {
         XCTAssertEqual(encodeQuery(Query(format: "age = %@ OR age = %@", 18, 21)), "query=\(encodeURL(["$or" : [["age" : 18], ["age" : 21]]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age == 18 || \Person.age == 21)), "query=\(encodeURL(["$or" : [["age" : 18], ["age" : 21]]]))")
+        XCTAssertEqual(Query(\Person.age == 18 || \Person.age == 21).predicate, NSPredicate(format: "age = %@ OR age = %@", argumentArray: [18, 21]))
     }
     
     func testQueryAnd() {
         XCTAssertEqual(encodeQuery(Query(format: "age = %@ AND age = %@", 18, 21)), "query=\(encodeURL(["$and" : [["age" : 18], ["age" : 21]]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.age == 18 && \Person.age == 21)), "query=\(encodeURL(["$and" : [["age" : 18], ["age" : 21]]]))")
+        XCTAssertEqual(Query(\Person.age == 18 && \Person.age == 21).predicate, NSPredicate(format: "age = %@ AND age = %@", argumentArray: [18, 21]))
     }
     
     func testQueryAndOptimized() {
         XCTAssertEqual(encodeQuery(Query(format: "name = %@ AND age = %@", "Victor", 21)), "query=\(encodeURL(["name" : "Victor", "age" : 21]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.name == "Victor" && \Person.age == 21)), "query=\(encodeURL(["name" : "Victor", "age" : 21]))")
     }
     
     func testQueryNot() {
         XCTAssertEqual(encodeQuery(Query(format: "NOT age = %@", 30)), "query=\(encodeURL(["$not" : [["age" : 30]]]))")
+        XCTAssertEqual(encodeQuery(Query(!(\Person.age == 30))), "query=\(encodeURL(["$not" : [["age" : 30]]]))")
+        XCTAssertEqual(Query(!(\Person.age == 30)).predicate, NSPredicate(format: "NOT age = %@", argumentArray: [30]))
     }
     
     func testQueryRegex() {
@@ -156,10 +183,58 @@ class QueryTest: XCTestCase {
 
     func testQueryBeginsWith() {
         XCTAssertEqual(encodeQuery(Query(format: "name BEGINSWITH %@", "acme")), "query=\(encodeURL(["name" : ["$regex" : "^acme"]]))")
+        XCTAssertEqual(encodeQuery(Query(\Person.name =% "acme")), "query=\(encodeURL(["name" : ["$regex" : "^acme"]]))")
+        XCTAssertEqual(Query(\Person.name =% "acme").predicate, NSPredicate(format: "name BEGINSWITH %@", argumentArray: ["acme"]))
     }
 
     func testQueryGeoWithinCenterSphere() {
         let result = convert(urlQueryItems: Query(format: "location = %@", MKCircle(center: CLLocationCoordinate2D(latitude: 40.74, longitude: -74), radius: 10000)).urlQueryItems)!
+        let expect = convert(jsonDictionary: [
+            "query" : [
+                "location" : [
+                    "$geoWithin" : [
+                        "$centerSphere" : [
+                            [-74, 40.74],
+                            10/6378.1
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        
+        XCTAssertEqual(result.count, expect.count)
+        if result.count == expect.count {
+            let resultQuery = try! JSONSerialization.jsonObject(with: result["query"]!.data(using: .utf8)!) as! [String : [String : [String : [Any]]]]
+            let expectQuery = try! JSONSerialization.jsonObject(with: expect["query"]!.data(using: .utf8)!) as! [String : [String : [String : [Any]]]]
+            
+            let centerSphereResult = resultQuery["location"]!["$geoWithin"]!["$centerSphere"]!
+            let centerSphereExpect = expectQuery["location"]!["$geoWithin"]!["$centerSphere"]!
+            
+            XCTAssertEqual(centerSphereResult.count, 2)
+            XCTAssertEqual(centerSphereExpect.count, 2)
+            
+            if centerSphereResult.count == 2 && centerSphereExpect.count == 2 {
+                let coordinatesResult = centerSphereResult[0] as! [Double]
+                let coordinatesExpect = centerSphereExpect[0] as! [Double]
+                
+                XCTAssertEqual(coordinatesResult.count, 2)
+                XCTAssertEqual(coordinatesExpect.count, 2)
+                
+                XCTAssertEqual(coordinatesResult, coordinatesExpect)
+                
+                XCTAssertEqual(centerSphereResult[1] as! Double, centerSphereExpect[1] as! Double, accuracy: 0.00001)
+            }
+        }
+    }
+    
+    class Place {
+        
+        @objc var location: GeoPoint?
+        
+    }
+    
+    func testQueryGeoWithinCenterSphereKeyPath() {
+        let result = convert(urlQueryItems: Query(\Place.location == MKCircle(center: CLLocationCoordinate2D(latitude: 40.74, longitude: -74), radius: 10000)).urlQueryItems)!
         let expect = convert(jsonDictionary: [
             "query" : [
                 "location" : [
@@ -245,12 +320,61 @@ class QueryTest: XCTestCase {
         }
     }
     
+    func testQueryGeoWithinPolygonKeyPath() {
+        var coordinates = [CLLocationCoordinate2D(latitude: 40.74, longitude: -74), CLLocationCoordinate2D(latitude: 50.74, longitude: -74), CLLocationCoordinate2D(latitude: 40.74, longitude: -64)]
+        let result = convert(urlQueryItems: Query(\Place.location == MKPolygon(coordinates: &coordinates, count: 3)).urlQueryItems)!
+        let expect = convert(jsonDictionary: [
+            "query" : [
+                "location" : [
+                    "$geoWithin" : [
+                        "$geometry" : [
+                            "type" : "Polygon",
+                            "coordinates" : [
+                                [-74, 40.74],
+                                [-74, 50.74],
+                                [-64, 40.74]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        
+        XCTAssertEqual(result.count, expect.count)
+        if result.count == expect.count {
+            let result = try! JSONSerialization.jsonObject(with: result["query"]!.data(using: .utf8)!) as? [String : [String : [String : [String : AnyObject]]]]
+            let expect = try! JSONSerialization.jsonObject(with: expect["query"]!.data(using: .utf8)!) as? [String : [String : [String : [String : AnyObject]]]]
+            
+            if var result = result, var expect = expect {
+                let geometryResult = result["location"]!["$geoWithin"]!["$geometry"]!
+                let geometryExpect = expect["location"]!["$geoWithin"]!["$geometry"]!
+                
+                XCTAssertEqual(geometryResult["type"] as? String, geometryExpect["type"] as? String)
+                
+                let coordinatesResult = geometryResult["coordinates"] as? [[Double]]
+                let coordinatesExpect = geometryExpect["coordinates"] as? [[Double]]
+                
+                XCTAssertNotNil(coordinatesResult)
+                XCTAssertNotNil(coordinatesExpect)
+                
+                if let coordinatesResult = coordinatesResult, let coordinatesExpect = coordinatesExpect {
+                    XCTAssertEqual(coordinatesResult.count, coordinatesExpect.count)
+                    for index in coordinatesResult.indices {
+                        XCTAssertEqual(coordinatesResult[index].count, coordinatesExpect[index].count)
+                    }
+                }
+            }
+        }
+    }
+    
     func testSortAscending() {
         XCTAssertEqual(encodeQuery(Query(sortDescriptors: [NSSortDescriptor(key: "name", ascending: true)])), "sort=\(encodeURL(["name" : 1]))")
+        XCTAssertEqual(encodeQuery(Query().ascending(\Person.name)), "sort=\(encodeURL(["name" : 1]))")
     }
     
     func testSortDescending() {
         XCTAssertEqual(encodeQuery(Query(sortDescriptors: [NSSortDescriptor(key: "name", ascending: false)])), "sort=\(encodeURL(["name" : -1]))")
+        XCTAssertEqual(encodeQuery(Query().descending(\Person.name)), "sort=\(encodeURL(["name" : -1]))")
     }
     
     func testSkip() {
@@ -294,6 +418,19 @@ class QueryTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
     
+    func testPredicateContainsKeyPath() {
+        let result = encodeQuery(Query(\Person.name %=% "f"))
+        let json = [
+            "name" : [
+                "$regex" : ".*f.*"
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+        
+        XCTAssertEqual(Query(\Person.name %=% "f").predicate, NSPredicate(format: "name CONTAINS %@", "f"))
+    }
+    
     func testPredicateEndsWith() {
         let result = encodeQuery(Query(format: "name ENDSWITH %@", "m"))
         let json = [
@@ -303,6 +440,19 @@ class QueryTest: XCTestCase {
         ]
         let expected = "query=\(encodeURL(json))"
         XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateEndsWithKeyPath() {
+        let result = encodeQuery(Query(\Person.name %= "m"))
+        let json = [
+            "name" : [
+                "$regex" : ".*m"
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+        
+        XCTAssertEqual(Query(\Person.name %= "m").predicate, NSPredicate(format: "name ENDSWITH %@", "m"))
     }
     
     func testPredicateLike() {
@@ -404,9 +554,29 @@ class QueryTest: XCTestCase {
         XCTAssertEqual(queryItems?.filter { $0.name == "sort" }.first?.value, "{\"name\":1}")
     }
     
+    func testAscendingKeyPath() {
+        let query = Query()
+        query.ascending(\Person.name)
+        let queryItems = query.urlQueryItems
+        
+        XCTAssertNotNil(queryItems)
+        XCTAssertEqual(queryItems?.count, 1)
+        XCTAssertEqual(queryItems?.filter { $0.name == "sort" }.first?.value, "{\"name\":1}")
+    }
+    
     func testDescending() {
         let query = Query()
         query.descending("name")
+        let queryItems = query.urlQueryItems
+        
+        XCTAssertNotNil(queryItems)
+        XCTAssertEqual(queryItems?.count, 1)
+        XCTAssertEqual(queryItems?.filter { $0.name == "sort" }.first?.value, "{\"name\":-1}")
+    }
+    
+    func testDescendingKeyPath() {
+        let query = Query()
+        query.descending(\Person.name)
         let queryItems = query.urlQueryItems
         
         XCTAssertNotNil(queryItems)

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -1729,17 +1729,34 @@ class SyncStoreTests: StoreTestCase {
             setURLProtocol(nil)
         }
         
-        let query = Query(format: "personId == %@", personId)
-        
-        let request = store.find(query, options: nil)
         do {
-            let results = try request.waitForResult(timeout: defaultTimeout).value()
-            XCTAssertNotNil(results.first)
-            if let result = results.first {
-                XCTAssertEqual(result.personId, personId)
+            let query = Query(format: "personId == %@", personId)
+            
+            let request = store.find(query, options: nil)
+            do {
+                let results = try request.waitForResult(timeout: defaultTimeout).value()
+                XCTAssertNotNil(results.first)
+                if let result = results.first {
+                    XCTAssertEqual(result.personId, personId)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
             }
-        } catch {
-            XCTFail(error.localizedDescription)
+        }
+        
+        do {
+            let query = Query(\Person.personId == personId)
+            
+            let request = store.find(query, options: nil)
+            do {
+                let results = try request.waitForResult(timeout: defaultTimeout).value()
+                XCTAssertNotNil(results.first)
+                if let result = results.first {
+                    XCTAssertEqual(result.personId, personId)
+                }
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
         }
     }
     
@@ -2017,7 +2034,7 @@ class SyncStoreTests: StoreTestCase {
             let query = Query {
                 $0.skip = skip
                 $0.limit = limit
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2055,7 +2072,7 @@ class SyncStoreTests: StoreTestCase {
             
             let query = Query {
                 $0.limit = 5
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2091,7 +2108,7 @@ class SyncStoreTests: StoreTestCase {
             
             let query = Query {
                 $0.skip = 5
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2128,7 +2145,7 @@ class SyncStoreTests: StoreTestCase {
             let query = Query {
                 $0.skip = 6
                 $0.limit = 6
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2164,7 +2181,7 @@ class SyncStoreTests: StoreTestCase {
             
             let query = Query {
                 $0.skip = 10
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2188,7 +2205,7 @@ class SyncStoreTests: StoreTestCase {
             
             let query = Query {
                 $0.skip = 11
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.find(query, options: try! Options(readPolicy: .forceLocal)) {
@@ -2266,7 +2283,7 @@ class SyncStoreTests: StoreTestCase {
                 $0.predicate = NSPredicate(format: "acl.creator == %@", user.userId)
                 $0.skip = skip
                 $0.limit = limit
-                $0.ascending("name")
+                $0.ascending(\Person.name)
             }
             
             store.pull(query) { results, error in


### PR DESCRIPTION
#### Description

Allowing perform queries using KeyPath syntax

#### Changes

- Mainly the `Query` class and a few overload operators

#### Tests

- Same unit tests but now also checking the KeyPath syntax produce the same results
