### PR TITLE
SwiftLint warning fix

### DIFF
--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -9,14 +9,6 @@
 import Foundation
 import PromiseKit
 
-func +(lhs: NSDecimalNumber, rhs: NSDecimalNumber) -> NSDecimalNumber {
-    return lhs.adding(rhs)
-}
-
-func *(lhs: NSDecimalNumber, rhs: NSDecimalNumber) -> NSDecimalNumber {
-    return lhs.multiplying(by: rhs)
-}
-
 /// Class to interact with a specific collection in the backend.
 open class DataStore<T: Persistable> where T: NSObject {
     

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -1282,8 +1282,8 @@ open class DataStore<T: Persistable> where T: NSObject {
 
 extension DataStore: Hashable {
     
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
     }
     
     public static func ==(lhs: DataStore<T>, rhs: DataStore<T>) -> Bool {

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -3750,6 +3750,16 @@ class NetworkStoreTests: StoreTestCase {
         let addr1 = Unmanaged.passUnretained(ds1).toOpaque()
         let addr2 = Unmanaged.passUnretained(ds2).toOpaque()
         XCTAssertNotEqual(addr1, addr2)
+        XCTAssertNotEqual(ds1, ds2)
+        XCTAssertNotEqual(ds1.hashValue, ds2.hashValue)
+        
+        var h1 = Hasher()
+        ds1.hash(into: &h1)
+        
+        var h2 = Hasher()
+        ds2.hash(into: &h2)
+        
+        XCTAssertNotEqual(h1.finalize(), h2.finalize())
     }
     
     func testFindCancel() {


### PR DESCRIPTION
#### Description

New version of SwiftLint detected a new warning

#### Changes

- Minor change how the `hashValue` is calculated. `hashValue` is deprecated and the new `Hasher` should be used instead

#### Tests

- Same unit tests
