### PR TITLE
MLIBZ-2838: Bugfix crash on signpost calls

### DIFF
--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -754,9 +754,9 @@ extension RealmCache: DynamicCacheType {
             }
             try! cascadeDeletable.cascadeDelete(executor: RealmCascadeDeleteExecutor(realm: realm))
         } else if let schema = realm.schema[entityType] {
-            signpost(.begin, log: osLog, name: "Cascade Delete", "%{public}s", entityType)
+            signpost(.begin, log: osLog, name: "Cascade Delete", "%@", entityType)
             defer {
-                signpost(.end, log: osLog, name: "Cascade Delete", "%{public}s", entityType)
+                signpost(.end, log: osLog, name: "Cascade Delete", "%@", entityType)
             }
             schema.properties.forEachAutoreleasepool { property in
                 switch property.type {

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -754,9 +754,9 @@ extension RealmCache: DynamicCacheType {
             }
             try! cascadeDeletable.cascadeDelete(executor: RealmCascadeDeleteExecutor(realm: realm))
         } else if let schema = realm.schema[entityType] {
-            signpost(.begin, log: osLog, name: "Cascade Delete", "%s", entityType)
+            signpost(.begin, log: osLog, name: "Cascade Delete", "%{public}s", entityType)
             defer {
-                signpost(.end, log: osLog, name: "Cascade Delete", "%s", entityType)
+                signpost(.end, log: osLog, name: "Cascade Delete", "%{public}s", entityType)
             }
             schema.properties.forEachAutoreleasepool { property in
                 switch property.type {

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -45,9 +45,9 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
     }
     
     func savePendingOperation(_ pendingOperation: PendingOperationType) {
-        signpost(.begin, log: osLog, name: "Save PendingOperation", "Collection: %{public}s", pendingOperation.collectionName)
+        signpost(.begin, log: osLog, name: "Save PendingOperation", "Collection: %@", pendingOperation.collectionName)
         defer {
-            signpost(.end, log: osLog, name: "Save PendingOperation", "Collection: %{public}s", pendingOperation.collectionName)
+            signpost(.end, log: osLog, name: "Save PendingOperation", "Collection: %@", pendingOperation.collectionName)
         }
         executor.executeAndWait {
             try! self.realm.write {
@@ -84,9 +84,9 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
     }
     
     func removeAllPendingOperations(_ objectId: String?, methods: [String]?) {
-        signpost(.begin, log: osLog, name: "Remove All PendingOperations", "Object ID: %{public}s", String(describing: objectId))
+        signpost(.begin, log: osLog, name: "Remove All PendingOperations", "Object ID: %@", String(describing: objectId))
         defer {
-            signpost(.end, log: osLog, name: "Remove All PendingOperations", "Object ID: %{public}s", String(describing: objectId))
+            signpost(.end, log: osLog, name: "Remove All PendingOperations", "Object ID: %@", String(describing: objectId))
         }
         executor.executeAndWait {
             try! self.realm.write {

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -45,9 +45,9 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
     }
     
     func savePendingOperation(_ pendingOperation: PendingOperationType) {
-        signpost(.begin, log: osLog, name: "Save PendingOperation", "Collection: %s", pendingOperation.collectionName)
+        signpost(.begin, log: osLog, name: "Save PendingOperation", "Collection: %{public}s", pendingOperation.collectionName)
         defer {
-            signpost(.end, log: osLog, name: "Save PendingOperation", "Collection: %s", pendingOperation.collectionName)
+            signpost(.end, log: osLog, name: "Save PendingOperation", "Collection: %{public}s", pendingOperation.collectionName)
         }
         executor.executeAndWait {
             try! self.realm.write {
@@ -84,9 +84,9 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
     }
     
     func removeAllPendingOperations(_ objectId: String?, methods: [String]?) {
-        signpost(.begin, log: osLog, name: "Remove All PendingOperations", "Object ID: %s", String(describing: objectId))
+        signpost(.begin, log: osLog, name: "Remove All PendingOperations", "Object ID: %{public}s", String(describing: objectId))
         defer {
-            signpost(.end, log: osLog, name: "Remove All PendingOperations", "Object ID: %s", String(describing: objectId))
+            signpost(.end, log: osLog, name: "Remove All PendingOperations", "Object ID: %{public}s", String(describing: objectId))
         }
         executor.executeAndWait {
             try! self.realm.write {


### PR DESCRIPTION
#### Description

Adding {public} to the signpost calls when handled strings

#### Changes

- Signpost calls now uses `%@` instead of `%s` for string formatting

#### Tests

- Same unit tests
