### PR TITLE
MLIBZ-2855: Realm Crash when saving objects inside a List

### DIFF
--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -315,8 +315,6 @@ class CacheStoreTests: StoreTestCase {
             let expectationSave = expectation(description: "Save")
             expectationSave.expectedFulfillmentCount = 2
             
-            print((store.cache!.cache as! RealmCache<PersonCodable>).configuration.fileURL!.path)
-            
             store.save(person, options: nil) {
                 switch $0 {
                 case .success(let person):

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -298,7 +298,7 @@ class PersonCodable: Entity, Codable {
     }
     
     override func encode(to encoder: Encoder) throws {
-        var container = try encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(personId, forKey: .personId)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(age, forKey: .age)


### PR DESCRIPTION
#### Description

Objects that contains `List` as nested objects were crashing during save calls

#### Changes

- List needs to be detached from Realm

#### Tests

- Unit test added to cover the scenario reported by the support ticket
