### PR TITLE
MLIBZ-2864: Allow clearCache() to delete nested objects

### DIFF
--- a/Kinvey/Kinvey/Cache.swift
+++ b/Kinvey/Kinvey/Cache.swift
@@ -55,6 +55,8 @@ internal protocol CacheType: class {
     
     func clear(query: Query?)
     
+    func clear(query: Query?, cascadeDelete: Bool)
+    
     func clear(syncQueries: [Query]?)
     
     func detach(entities: AnyRandomAccessCollection<Type>, query: Query?) -> AnyRandomAccessCollection<Type>
@@ -157,6 +159,7 @@ class AnyCache<T: Persistable>: CacheType {
     private let _removeEntities: (AnyRandomAccessCollection<Type>) -> Bool
     private let _removeByQuery: (Query) -> Int
     private let _clear: (Query?) -> Void
+    private let _clearCascadeDelete: (Query?, Bool) -> Void
     private let _clearSyncQueries: ([Query]?) -> Void
     private let _detach: (AnyRandomAccessCollection<Type>, Query?) -> AnyRandomAccessCollection<Type>
     private let _lastSync: (Query) -> Date?
@@ -187,6 +190,7 @@ class AnyCache<T: Persistable>: CacheType {
         _removeEntities = cache.remove(entities:)
         _removeByQuery = cache.remove(byQuery:)
         _clear = cache.clear(query:)
+        _clearCascadeDelete = cache.clear(query: cascadeDelete:)
         _clearSyncQueries = cache.clear(syncQueries:)
         _detach = cache.detach(entities: query:)
         _lastSync = cache.lastSync(query:)
@@ -243,6 +247,10 @@ class AnyCache<T: Persistable>: CacheType {
     
     func clear(query: Query?) {
         _clear(query)
+    }
+    
+    func clear(query: Query?, cascadeDelete: Bool) {
+        _clearCascadeDelete(query, cascadeDelete)
     }
     
     func clear(syncQueries: [Query]?) {

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -1149,8 +1149,8 @@ open class DataStore<T: Persistable> where T: NSObject {
     }
 
     /// Clear all data for the collection attached to the DataStore.
-    open func clearCache(query: Query? = nil) {
-        cache?.clear(query: query)
+    open func clearCache(query: Query? = nil, cascadeDelete: Bool = false) {
+        cache?.clear(query: query, cascadeDelete: cascadeDelete)
     }
     
     private lazy var channelName: String = {

--- a/Kinvey/KinveyTests/MemoryCache.swift
+++ b/Kinvey/KinveyTests/MemoryCache.swift
@@ -110,6 +110,10 @@ class MemoryCache<T: Persistable>: Cache<T>, CacheType where T: NSObject {
         memory.removeAll()
     }
     
+    func clear(query: Query?, cascadeDelete: Bool) {
+        memory.removeAll()
+    }
+    
     func clear(syncQueries: [Query]?) {
         memory.removeAll()
     }

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -36,7 +36,11 @@ enum PersonObjCEnum: Int {
 class Person: Entity {
     
     @objc
-    dynamic var personId: String?
+    dynamic var personId: String? {
+        didSet {
+            entityId = personId
+        }
+    }
     
     @objc
     dynamic var name: String?


### PR DESCRIPTION
#### Description

Allow `DataStore.clearCache()` to delete nested objects

#### Changes

- `DataStore.clearCache()` now have an optional parameter called `cascadeDelete` with the default value `false`

#### Tests

- Unit tests now tests `clearCache()` with and without cascade delete
