### PR TITLE
MLIBZ-2870: Converting dates in queries to ISO 8601

### DIFF
--- a/Kinvey/Kinvey/CustomEndpoint.swift
+++ b/Kinvey/Kinvey/CustomEndpoint.swift
@@ -39,7 +39,7 @@ open class CustomEndpoint {
         }
         
         public convenience init<T>(_ object: T) throws where T: Encodable {
-            let data = try JSONEncoder().encode(object)
+            let data = try jsonEncoder.encode(object)
             let json = try JSONSerialization.jsonObject(with: data) as! JsonDictionary
             self.init(json)
         }
@@ -395,7 +395,7 @@ open class CustomEndpoint {
                         response.isOK,
                         let data = data
                     {
-                        let objArray = try JSONDecoder().decode([T].self, from: data)
+                        let objArray = try jsonDecoder.decode([T].self, from: data)
                         resolver.fulfill(objArray)
                     } else {
                         resolver.reject(buildError(data, response, error, client))

--- a/Kinvey/Kinvey/Date.swift
+++ b/Kinvey/Kinvey/Date.swift
@@ -9,9 +9,17 @@
 import Foundation
 
 extension Date {
+    
+    static let dateWriteFormatter: DateFormatter = {
+        let wFormatter = DateFormatter()
+        wFormatter.locale = Locale(identifier: "en_US_POSIX")
+        wFormatter.timeZone = TimeZone(identifier: "UTC")
+        wFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return wFormatter
+    }()
 
     public func toISO8601() -> String {
-        return KinveyDateTransform().transformToJSON(self)!
+        return Date.dateWriteFormatter.string(from: self)
     }
     
 }

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -123,7 +123,7 @@ enum HttpHeader {
         case .userAgent:
             return "Kinvey SDK \(Bundle(for: Client.self).infoDictionary!["CFBundleShortVersionString"]!) (Swift \(swiftVersion))"
         case .deviceInfo:
-            let data = try! JSONEncoder().encode(DeviceInfo())
+            let data = try! jsonEncoder.encode(DeviceInfo())
             return String(data: data, encoding: .utf8)
         }
     }

--- a/Kinvey/Kinvey/JSONParser.swift
+++ b/Kinvey/Kinvey/JSONParser.swift
@@ -76,16 +76,16 @@ extension JSONDecodable where Self: JSONEncodable {
 extension JSONDecodable where Self: Decodable {
     
     static func decodeDecodable(from data: Data) throws -> Self {
-        return try JSONDecoder().decode(Self.self, from: data)
+        return try jsonDecoder.decode(Self.self, from: data)
     }
     
     static func decodeDecodableArray(from data: Data) throws -> [Any] {
-        return try JSONDecoder().decode([Self].self, from: data)
+        return try jsonDecoder.decode([Self].self, from: data)
     }
     
     static func decodeDecodable(from dictionary: [String : Any]) throws -> Self {
         let data = try JSONSerialization.data(withJSONObject: dictionary)
-        return try JSONDecoder().decode(Self.self, from: data)
+        return try jsonDecoder.decode(Self.self, from: data)
     }
     
 }
@@ -114,7 +114,7 @@ extension JSONEncodable {
 extension JSONEncodable where Self: Encodable {
     
     func encodeEncodable() throws -> [String : Any] {
-        let data = try JSONEncoder().encode(self)
+        let data = try jsonEncoder.encode(self)
         return try JSONSerialization.jsonObject(with: data) as! [String : Any]
     }
     

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -218,6 +218,27 @@ public var logLevel: LogLevel = LogLevel.defaultLevel {
     }
 }
 
+public var jsonDecoder: JSONDecoder = {
+    let jsonDecoder = JSONDecoder()
+    jsonDecoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
+        let dateString = try decoder.singleValueContainer().decode(String.self)
+        guard let date = dateString.toDate() else {
+            throw Error.invalidOperation(description: "\(dateString) is not date")
+        }
+        return date
+    })
+    return jsonDecoder
+}()
+
+public var jsonEncoder: JSONEncoder = {
+    let jsonEncoder = JSONEncoder()
+    jsonEncoder.dateEncodingStrategy = .custom({ (date, encoder) in
+        var container = encoder.singleValueContainer()
+        try container.encode(date.toISO8601())
+    })
+    return jsonEncoder
+}()
+
 public let defaultTag = "kinvey"
 let groupId = "_group_"
 

--- a/Kinvey/Kinvey/Query.swift
+++ b/Kinvey/Kinvey/Query.swift
@@ -108,7 +108,14 @@ public final class Query: NSObject, BuilderType {
                     }
                 }
                 keyPath = keyPaths.joined(separator: ".")
-            } else if let persistableType = type as? Persistable.Type, let (translatedKeyPath, _) = persistableType.propertyMapping(keyPath) {
+            } else if let persistableType = type as? Persistable.Type,
+                let (translatedKeyPath, _) = persistableType.propertyMapping(keyPath)
+            {
+                keyPath = translatedKeyPath
+            } else if let persistableType = type as? Persistable.Type,
+                let _translatedKeyPath = try? persistableType.translate(property: keyPath),
+                let translatedKeyPath = _translatedKeyPath
+            {
                 keyPath = translatedKeyPath
             }
             return NSExpression(forKeyPath: keyPath)
@@ -130,6 +137,9 @@ public final class Query: NSObject, BuilderType {
                     return NSExpression(forConstantValue: transform.transformToJSON(expression.constantValue))
                 }
             #endif
+            if let date = expression.constantValue as? Date {
+                return NSExpression(forConstantValue: date.toISO8601())
+            }
             return expression
         default:
             return expression

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -331,6 +331,7 @@ internal class RealmCache<T: Persistable>: Cache<T>, CacheType where T: NSObject
     
     private func detach(_ list: ListBase) -> [Object] {
         var result = [Object]()
+        result.reserveCapacity(list.count)
         let rlmArray = list._rlmArray
         for i in 0 ..< rlmArray.count {
             let item = rlmArray.object(at: i) as! Object

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -183,6 +183,9 @@ class PersonCodable: Entity, Codable {
     dynamic var age: Int = 0
     
     @objc
+    dynamic var date: Date?
+    
+    @objc
     dynamic var geolocation: GeoPoint?
     
     @objc
@@ -231,6 +234,7 @@ class PersonCodable: Entity, Codable {
         case personId = "_id"
         case name
         case age
+        case date
         case address
         case addresses
         case geolocation
@@ -251,6 +255,7 @@ class PersonCodable: Entity, Codable {
         personId = try container.decodeIfPresent(String.self, forKey: .personId)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         age = try container.decode(Int.self, forKey: .age)
+        date = try container.decodeIfPresent(Date.self, forKey: .date)
         address = try container.decodeIfPresent(AddressCodable.self, forKey: .address)
         if let addresses = try container.decodeIfPresent(List<AddressCodable>.self, forKey: .addresses) {
             self.addresses.removeAll()
@@ -306,6 +311,7 @@ class PersonCodable: Entity, Codable {
         try container.encodeIfPresent(personId, forKey: .personId)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(age, forKey: .age)
+        try container.encodeIfPresent(date, forKey: .date)
         try container.encodeIfPresent(address, forKey: .address)
         try container.encodeIfPresent(addresses, forKey: .addresses)
         try container.encodeIfPresent(stringValues, forKey: .stringValues)

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -493,7 +493,7 @@ class QueryTest: XCTestCase {
         let date = Date()
         let result = encodeQuery(Query(format: "date == %@", date))
         let json = [
-            "date" : date.timeIntervalSince1970
+            "date" : date.toISO8601()
         ]
         let expected = "query=\(encodeURL(json))"
         XCTAssertEqual(result, expected)


### PR DESCRIPTION
#### Description

Converting dates in queries to ISO 8601 so queries will return the expected values in both local and network calls

#### Changes

- JSON Decoder and Encoder now converts ISO 8601 by default
- Allow users to set custom JSON Decoder and Encoder
- Dates on queries converts into ISO 8601 but only for network calls

#### Tests

- Tests for query local and network calls
