### PR TITLE
MLIBZ-2873: blocking UI thread

### DIFF
--- a/Kinvey/Kinvey/Executor.swift
+++ b/Kinvey/Kinvey/Executor.swift
@@ -13,9 +13,9 @@ class Executor {
     fileprivate let operationQueue: OperationQueue
     fileprivate let thread: Thread
     
-    init() {
-        operationQueue = OperationQueue.current!
+    init(operationQueue: OperationQueue = OperationQueue.current!) {
         operationQueue.maxConcurrentOperationCount = 1
+        self.operationQueue = operationQueue
         thread = Thread.current
     }
     

--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -2701,7 +2701,7 @@ class CacheStoreTests: StoreTestCase {
                 }
             }
             weak var expectationSync = expectation(description: "Sync")
-            var query = Query(format: "age == %@", 23)
+            let query = Query(format: "age == %@", 23)
             store.sync(query, options: nil) { (result: Result<(UInt, AnyRandomAccessCollection<Person>), [Swift.Error]>) in
                 switch result {
                 case .success(let count, let persons):
@@ -2877,7 +2877,7 @@ class CacheStoreTests: StoreTestCase {
             }
             weak var expectationSync = expectation(description: "Sync")
             
-            var query = Query(format: "age == %@", 23)
+            let query = Query(format: "age == %@", 23)
             store.sync(query, options: nil) { (result: Result<(UInt, AnyRandomAccessCollection<Person>), [Swift.Error]>) in
                 switch result {
                 case .success(let count, let persons):
@@ -3985,7 +3985,7 @@ class CacheStoreTests: StoreTestCase {
             weak var expectationFind = expectation(description: "Find")
             var options = try! Options()
             options.readPolicy = .forceNetwork
-            var query = Query(format: "age == %@", 23)
+            let query = Query(format: "age == %@", 23)
             store.find(query, options: options) { (result: Result<AnyRandomAccessCollection<Person>, Swift.Error>) in
                 switch result {
                 case .success(let persons):
@@ -4177,7 +4177,7 @@ class CacheStoreTests: StoreTestCase {
             weak var expectationFind = expectation(description: "Find")
             var options = try! Options()
             options.readPolicy = .forceNetwork
-            var query = Query(format: "age == %@", 23)
+            let query = Query(format: "age == %@", 23)
             store.find(query, options: options) { (result: Result<AnyRandomAccessCollection<Person>, Swift.Error>) in
                 switch result {
                 case .success(let persons):
@@ -4343,7 +4343,7 @@ class CacheStoreTests: StoreTestCase {
             weak var expectationFind = expectation(description: "Find")
             var options = try! Options()
             options.readPolicy = .forceNetwork
-            var query = Query()
+            let query = Query()
             store.find(query, options: options) { (result: Result<AnyRandomAccessCollection<Person>, Swift.Error>) in
                 switch result {
                 case .success(let persons):

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -4758,14 +4758,14 @@ class DeltaSetCacheTestCase: KinveyTestCase {
         
         XCTAssertNotNil(count)
         
-        guard let count1 = count else {
+        guard count != nil else {
             return
         }
         
         let options = try! Options(maxSizePerResultSet: 1)
         
         do {
-            let results = try dataStore.pull(options: options).waitForResult(timeout: defaultTimeout).value()
+            _ = try dataStore.pull(options: options).waitForResult(timeout: defaultTimeout).value()
             XCTFail("Error is expected")
         } catch {
             XCTAssertTimeoutError(error)

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -7189,7 +7189,7 @@ class SyncStoreTests: StoreTestCase {
             weak var expectationFind = expectation(description: "Find")
             var options = try! Options()
             options.readPolicy = .forceNetwork
-            var query = Query(format: "age == %@", 23)
+            let query = Query(format: "age == %@", 23)
             store.find(query, options: options) { (result: Result<AnyRandomAccessCollection<Person>, Swift.Error>) in
                 switch result {
                 case .success(let persons):


### PR DESCRIPTION
#### Description

`Executor` was blocking the UI for long periods of time

#### Changes

- `RealmCache` does not uses `Executor` anymore, but because we lazy load Realm objects and those objects are locked to a thread we still need to use `Executor` in some spots

#### Tests

- Same unit tests
