### PR TITLE
MLIBZ-2888: Make Client.userChangedListener public

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -17,8 +17,8 @@ open class Client: Credential {
     /// Shared client instance for simplicity. Use this instance if *you don't need* to handle with multiple Kinvey environments.
     public static let sharedClient = Client()
     
-    typealias UserChangedListener = (User?) -> Void
-    var userChangedListener: UserChangedListener?
+    public typealias UserChangedListener = (User?) -> Void
+    public var userChangedListener: UserChangedListener?
     
     /// It holds the `User` instance after logged in. If this variable is `nil` means that there's no logged user, which is necessary for some calls to in a Kinvey environment.
     open internal(set) var activeUser: User? {


### PR DESCRIPTION
#### Description

Making `Client.userChangedListener` public allows perform actions when the user is not present anymore, like in situations where the token expired for example

#### Changes

- `Client.userChangedListener` is now public

#### Tests

- Same unit tests
