### PR TITLE
MLIBZ-3133: Missing JSON Content-Type HTTP Header

### DIFF
--- a/Kinvey/Kinvey/HttpResponse.swift
+++ b/Kinvey/Kinvey/HttpResponse.swift
@@ -67,7 +67,7 @@ struct HttpResponse: Response {
     }
     
     var contentTypeIsJson: Bool {
-        guard let contentType = allHeaderFields?["content-type"] as? String else {
+        guard let contentType = (allHeaderFields?["content-type"] as? String) ?? (allHeaderFields?["Content-Type"] as? String) else {
             return false
         }
         return contentType == "application/json" || contentType.hasPrefix("application/json;")

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -159,7 +159,7 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
             urlRequest.setValue(UUID().uuidString, forHTTPHeaderField: KinveyHeaderField.requestId)
-            try! urlRequest.setBody(result.jsonArray)
+            try! urlRequest.setBody(json: result.jsonArray)
             results.append(
                 RealmPendingOperation(
                     request: urlRequest,

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -152,14 +152,14 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
             let urls = Set(result.urls)
             guard urls.count == 1,
                 let url = urls.first,
-                let data = try? JSONSerialization.data(withJSONObject: result.jsonArray)
+                JSONSerialization.isValidJSONObject(result.jsonArray)
             else {
                 return
             }
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
             urlRequest.setValue(UUID().uuidString, forHTTPHeaderField: KinveyHeaderField.requestId)
-            urlRequest.httpBody = data
+            try! urlRequest.setBody(result.jsonArray)
             results.append(
                 RealmPendingOperation(
                     request: urlRequest,

--- a/Kinvey/KinveyTests/KinveyURLProtocol.swift
+++ b/Kinvey/KinveyTests/KinveyURLProtocol.swift
@@ -166,6 +166,7 @@ class KinveyURLProtocol: URLProtocol {
                 
                 switch httpMethod {
                 case "POST":
+                    XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"] as? String, "application/json; charset=utf-8")
                     let json = try! JSONSerialization.jsonObject(with: request)
                     let kinveyApiVersion = request.allHTTPHeaderFields?["X-Kinvey-API-Version"]
                     if var json = json as? [String : Any] {


### PR DESCRIPTION
#### Description

Bugfix: Missing JSON `Content-Type` HTTP Header

#### Changes

- Push multiple items requests were missing the `Content-Type` HTTP Header

#### Tests

- Adding a check (to existing tests) if the request is sent with the right HTTP `Content-Type` header
