### PR TITLE
MLIBZ-3134: checking if all properties are sent correctly

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -276,6 +276,8 @@
 		578B80721EE746EF004D92A6 /* SyncStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5753BB3B1C23F29000EB9D3A /* SyncStoreTests.swift */; };
 		578B80741EE74E46004D92A6 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57E6BD001EC51F80000E5C52 /* PubNub.framework */; };
 		578B80761EE876C5004D92A6 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E1C3AC1C17EC9500578974 /* UserTests.swift */; };
+		578D9152233190BF0001152E /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572005C91D342B2800AE9AC5 /* Book.swift */; };
+		578D9153233190C20001152E /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572005C91D342B2800AE9AC5 /* Book.swift */; };
 		578D9FE41E8DE53900C2B280 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BEAE2E1C98805E00479206 /* QuartzCore.framework */; };
 		578D9FE51E8DE53900C2B280 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BEAE2C1C98805600479206 /* CoreGraphics.framework */; };
 		578D9FE61E8DE53900C2B280 /* Kinvey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; };
@@ -3342,6 +3344,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				578D9153233190C20001152E /* Book.swift in Sources */,
 				57529845226FB1AD002FA614 /* Person.swift in Sources */,
 				57529847226FB1E4002FA614 /* KinveyTestCase.swift in Sources */,
 				57529846226FB1C6002FA614 /* KinveyURLProtocol.swift in Sources */,
@@ -3356,6 +3359,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				578D9152233190BF0001152E /* Book.swift in Sources */,
 				5752988E226FBADB002FA614 /* MockKinveyBackend.swift in Sources */,
 				5752988F226FBAFC002FA614 /* KinveyURLProtocol.swift in Sources */,
 				576B08DA22AEEE8800C22C95 /* MultiInsertSpec.swift in Sources */,

--- a/Kinvey/KinveyTests/Book.swift
+++ b/Kinvey/KinveyTests/Book.swift
@@ -46,6 +46,15 @@ class Book: Entity {
     
 }
 
+extension Book {
+    
+    convenience init(_ block: (Book) -> Void) {
+        self.init()
+        block(self)
+    }
+    
+}
+
 class BookEdition: Object, JSONDecodable, Mappable {
     
     convenience required init?(map: Map) {

--- a/Kinvey/KinveyTests/MultiInsertSpec.swift
+++ b/Kinvey/KinveyTests/MultiInsertSpec.swift
@@ -1728,7 +1728,7 @@ class MultiInsertSpec: QuickSpec {
                         expect(autoDataStore.pendingSyncCount()).to(equal(0))
                         expect(autoDataStore.pendingSyncEntities().count).to(equal(0))
                     }
-                    fit("push 2 new items") {
+                    it("push 2 new items") {
                         let books = [
                             Book { $0.title = "This 1 book" },
                             Book { $0.title = "This 2 book" },


### PR DESCRIPTION
#### Description

Steps to reproduce:

1. Create a few items with sync store2. Push them - the request looks like that:

```
POST https://baas.kinvey.com/appdata/kid_SkpK--qCb/Book
X-Kinvey-API-Version: 5
X-Kinvey-Device-Info: {"sdk":"iOS","pv":"Simulator Platform Version Unknown (x86_64)","os":"iOS","md":"iPhone","hv":1,"ov":"12.4"}
User-Agent: Kinvey SDK 3.26.0 (Swift 5.0)
Authorization: Kinvey *************************
X-Kinvey-Request-Id: 82A51DC3-BB97-4203-AF08-D1B40C690C61

[{"authors":[],"title":"This 1 book"},{"authors":[],"title":"This 2 book"}]
```

Expected result: the items are saved as they are in the backend and the sync queue is clearedActual results only one items is saved and some properties are omitted. The response to the above looks like:

```
201 created
Location: https://baas.kinvey.com/appdata/kid_SkpK--qCb/Book/5d5bfed95e24b02eeec8de17
Content-Length: 177
Content-Type: application/json; charset=utf-8
X-Kinvey-API-Version: 5
X-Kinvey-Request-Id: 89681198073d4e24a11874aa3a39b519
X-Kinvey-Rate-Limit: 600
Server: openresty
Date: Tue, 20 Aug 2019 14:08:25 GMT
X-Kinvey-Request-Start: 2019-08-20T14:08:25.392Z
Etag: W/"b1-jFDimJaoDjaBsK8eHXHF2K8YbRg"
X-Powered-By: Express

{"[{\"authors\":":[""],"_acl":{"creator":"5d5275b24b96d6774aeaf8c5"},"_kmd":{"lmt":"2019-08-20T14:08:25.392Z","ect":"2019-08-20T14:08:25.392Z"},"_id":"5d5bfed95e24b02eeec8de17"}
```

#### Changes

- No changes

#### Tests

- Adding one more test to make sure the request is properly built and sent
