### PR TITLE
fix: MLIBZ-3195, Codable support for File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,14 @@ before_script:
 - brew update
 - brew install swiftlint || brew upgrade swiftlint
 - brew install tree || brew upgrade tree
-# - brew upgrade carthage
 - tree -L 2 -P '*.framework' -I '*.dSYM' Carthage/Build
 - carthage version
+# Workaround for error `Segmentation fault: 11` during `carthage checkout`
+# downgrade carthage 0.34.0 to 0.33.0 (see issue and comment here: https://github.com/Carthage/Carthage/issues/2760#issuecomment-551499537)
+- if carthage version | grep 0.34.0; then
+    brew uninstall carthage;
+    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d453dd956dbfc5b724b0fdaeb14f9480f461479d/Formula/carthage.rb;
+  fi
 - xcpretty --version
 - if [ ! -d $( md5 Cartfile.resolved | awk '{ print "Carthage/" $4 ".zip" }' ) ]; then
     make cache;

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -333,18 +333,21 @@ open class FileStore<FileType: File> {
         )
         let promise = Promise<FileType> { resolver in
             request.execute() { (data, response, error) -> Void in
-                if let response = response, response.isOK,
-                    let data = data,
-                    let json = try? self.client.jsonParser.parseDictionary(from: data),
-                    let newFile = FileType(JSON: json) {
-                    newFile.path = file.path
-                    if let cache = self.cache {
-                        cache.save(newFile, beforeSave: nil)
+                do {
+                    if let response = response, response.isOK,
+                        let data = data {
+                        let newFile : FileType = try self.client.jsonParser.parseObject(FileType.self, from: data)
+                        newFile.path = file.path
+                        if let cache = self.cache {
+                            cache.save(newFile, beforeSave: nil)
+                        }
+                        
+                        resolver.fulfill(newFile)
+                    } else {
+                        resolver.reject(buildError(data, response, error, self.client))
                     }
-                    
-                    resolver.fulfill(newFile)
-                } else {
-                    resolver.reject(buildError(data, response, error, self.client))
+                } catch let err {
+                    resolver.reject(buildError(data, response, err, self.client))
                 }
             }
             if let requests = requests {
@@ -516,14 +519,16 @@ open class FileStore<FileType: File> {
                 let request = self.client.networkRequestFactory.blob.buildBlobUploadFile(file, options: options)
                 requests += request
                 request.execute { (data, response, error) -> Void in
-                    if let response = response, response.isOK,
-                        let data = data,
-                        let json = try? self.client.jsonParser.parseDictionary(from: data),
-                        let newFile = FileType(JSON: json)
-                    {
-                        resolver.fulfill((file: newFile, skip: nil))
-                    } else {
-                        resolver.reject(buildError(data, response, error, self.client))
+                    do {
+                        if let response = response, response.isOK,
+                            let data = data {
+                            let newFile : FileType = try self.client.jsonParser.parseObject(FileType.self, from: data)
+                            resolver.fulfill((file: newFile, skip: nil))
+                        } else {
+                            resolver.reject(buildError(data, response, error, self.client))
+                        }
+                    } catch let err {
+                        resolver.reject(buildError(data, response, err, self.client))
                     }
                 }
             }

--- a/Kinvey/Kinvey/FileStore.swift
+++ b/Kinvey/Kinvey/FileStore.swift
@@ -522,7 +522,7 @@ open class FileStore<FileType: File> {
                     do {
                         if let response = response, response.isOK,
                             let data = data {
-                            let newFile : FileType = try self.client.jsonParser.parseObject(FileType.self, from: data)
+                            let newFile = try self.client.jsonParser.parseObject(FileType.self, from: data)
                             resolver.fulfill((file: newFile, skip: nil))
                         } else {
                             resolver.reject(buildError(data, response, error, self.client))

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -594,8 +594,7 @@ struct HttpBlobRequestFactory: BlobRequestFactory {
             credential: client.activeUser,
             options: options
         )
-        
-        let bodyObject = file.toJSON()
+        let bodyObject = try! client.jsonParser.toJSON(file)
         request.request.setValue(file.mimeType ?? "application/octet-stream", forHTTPHeaderField: "X-Kinvey-Content-Type")
         request.setBody(json: bodyObject)
         return request

--- a/Kinvey/Kinvey/Keychain.swift
+++ b/Kinvey/Kinvey/Keychain.swift
@@ -33,8 +33,8 @@ class Keychain {
         self._client = client
         #if os(macOS)
         var appKey = appKey
-        if let xcTestConfigurationFilePath = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] {
-            appKey += URL(fileURLWithPath: xcTestConfigurationFilePath).lastPathComponent
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            appKey += URL(fileURLWithPath: cacheBasePath).lastPathComponent
         }
         #endif
         self.keychain = KeychainAccess.Keychain(service: "com.kinvey.Kinvey.\(appKey)").accessibility(.afterFirstUnlockThisDeviceOnly)

--- a/Kinvey/KinveyTests/CacheMigrationTestCaseStep2.swift
+++ b/Kinvey/KinveyTests/CacheMigrationTestCaseStep2.swift
@@ -51,8 +51,8 @@ class CacheMigrationTestCaseStep2: XCTestCase {
         let zip2DataPath = Bundle(for: CacheMigrationTestCaseStep2.self).url(forResource: "CacheMigrationTestCaseData2", withExtension: "zip")!
         var destination = Realm.Configuration.defaultConfiguration.fileURL!.deletingLastPathComponent()
         #if os(macOS)
-        if let xcTestConfigurationFilePath = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] {
-            destination = URL(fileURLWithPath: xcTestConfigurationFilePath).deletingLastPathComponent()
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            destination = URL(fileURLWithPath: cacheBasePath)
         }
         #endif
         removeItemIfExists(at: destination.appendingPathComponent("__MACOSX"))
@@ -79,8 +79,8 @@ class CacheMigrationTestCaseStep2: XCTestCase {
         if let fileURL = realmConfiguration.fileURL {
             var fileURL = fileURL
             #if os(macOS)
-            if let xcTestConfigurationFilePath = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] {
-                fileURL = URL(fileURLWithPath: xcTestConfigurationFilePath)
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+                fileURL = URL(fileURLWithPath: cacheBasePath).appendingPathComponent("todel")
             }
             #endif
             fileURL = fileURL.deletingLastPathComponent()
@@ -242,8 +242,8 @@ class CacheMigrationTestCaseStep2: XCTestCase {
         var realmConfiguration = Realm.Configuration.defaultConfiguration
         let lastPathComponent = realmConfiguration.fileURL!.lastPathComponent
         #if os(macOS)
-        if let xcTestConfigurationFilePath = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] {
-            realmConfiguration.fileURL = URL(fileURLWithPath: xcTestConfigurationFilePath)
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            realmConfiguration.fileURL = URL(fileURLWithPath: cacheBasePath).appendingPathComponent("todel")
         }
         #endif
         realmConfiguration.fileURL!.deleteLastPathComponent()

--- a/Kinvey/KinveyTests/FileTestCase.swift
+++ b/Kinvey/KinveyTests/FileTestCase.swift
@@ -16,12 +16,12 @@ import Nimble
     typealias Image = UIImage
 #endif
 
-class FileTestCase: StoreTestCase {
+class FileTestCase<FileType : File & MyFileProtocol>: StoreTestCase {
     
     let caminandes3TrailerURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("Caminandes 3 - TRAILER.mp4")
     let caminandes3TrailerImageURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("Caminandes 3 - TRAILER.jpg")
     var file: File?
-    var myFile: MyFile?
+    var myFile: FileType?
     var caminandes3TrailerFileSize: UInt64 {
         return try! FileManager.default.attributesOfItem(atPath: caminandes3TrailerURL.path).filter { $0.key == .size }.first!.value as! UInt64
     }
@@ -327,9 +327,7 @@ class FileTestCase: StoreTestCase {
                         "ect": "2016-12-03T08:52:19.204Z"
                     ],
                     "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                    "_expiresAt": "2016-12-10T08:52:19.488Z",
-                    "_requiredHeaders": [
-                    ]
+                    "_expiresAt": "2016-12-10T08:52:19.488Z"
                 ])
             case 1:
                 return HttpResponse(error: timeoutError)
@@ -386,9 +384,7 @@ class FileTestCase: StoreTestCase {
                         "ect": "2016-12-03T08:52:19.204Z"
                     ],
                     "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                    "_expiresAt": "2016-12-10T08:52:19.488Z",
-                    "_requiredHeaders": [
-                    ]
+                    "_expiresAt": "2016-12-10T08:52:19.488Z"
                 ])
             case 1:
                 return HttpResponse(error: timeoutError)
@@ -447,9 +443,7 @@ class FileTestCase: StoreTestCase {
                         "ect": "2016-12-03T08:52:19.204Z"
                     ],
                     "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                    "_expiresAt": "2016-12-10T08:52:19.488Z",
-                    "_requiredHeaders": [
-                    ]
+                    "_expiresAt": "2016-12-10T08:52:19.488Z"
                     ])
             case 1:
                 return HttpResponse(statusCode: 404, data: nil)
@@ -507,9 +501,7 @@ class FileTestCase: StoreTestCase {
                         "ect": "2016-12-03T08:52:19.204Z"
                     ],
                     "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                    "_expiresAt": "2016-12-10T08:52:19.488Z",
-                    "_requiredHeaders": [
-                    ]
+                    "_expiresAt": "2016-12-10T08:52:19.488Z"
                 ])
             case 1:
                 return HttpResponse(error: timeoutError)
@@ -568,9 +560,7 @@ class FileTestCase: StoreTestCase {
                         "ect": "2016-12-03T08:52:19.204Z"
                     ],
                     "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                    "_expiresAt": "2016-12-10T08:52:19.488Z",
-                    "_requiredHeaders": [
-                    ]
+                    "_expiresAt": "2016-12-10T08:52:19.488Z"
                 ])
             case 1:
                 return HttpResponse(error: timeoutError)
@@ -610,13 +600,13 @@ class FileTestCase: StoreTestCase {
             client.logNetworkEnabled = originalLogNetworkEnabled
         }
         
-        var file = MyFile()
+        var file = FileType()
         file.label = "trailer"
         file.publicAccessible = true
         self.file = file
         let path = caminandes3TrailerURL.path
         
-        let fileStore = FileStore<MyFile>()
+        let fileStore = FileStore<FileType>()
         
         var uploadProgressCount = 0
         
@@ -649,9 +639,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": "2016-12-03T08:52:19.204Z"
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                            "_expiresAt": "2016-12-10T08:52:19.488Z",
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": "2016-12-10T08:52:19.488Z"
                         ])
                     case 1:
                         if let stream = request.httpBodyStream {
@@ -759,7 +747,15 @@ class FileTestCase: StoreTestCase {
                 
                 XCTAssertNotNil(file)
                 XCTAssertNil(error)
-                
+                XCTAssertNotNil(uploadedFile)
+
+                defer {
+                    expectationUpload?.fulfill()
+                }
+
+                guard uploadedFile != nil else {
+                    return
+                }
                 file = uploadedFile!
                 
                 XCTAssertNotNil(file.path)
@@ -772,8 +768,6 @@ class FileTestCase: StoreTestCase {
                     let diff = memoryNow - memoryBefore
                     XCTAssertLessThan(diff, 15) //15 MB
                 }
-                
-                expectationUpload?.fulfill()
             }
             
             keyValueObservingExpectation(for: request.progress, keyPath: #selector(getter: request.progress.fractionCompleted).description) { (object, info) -> Bool in
@@ -881,9 +875,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": "2016-12-03T08:52:19.204Z"
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                            "_expiresAt": "2016-12-10T08:52:19.488Z",
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": "2016-12-10T08:52:19.488Z"
                         ])
                     case 1:
                         if let stream = request.httpBodyStream {
@@ -1110,9 +1102,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": "2016-12-03T08:52:19.204Z"
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                            "_expiresAt": "2016-12-10T08:52:19.488Z",
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": "2016-12-10T08:52:19.488Z"
                         ])
                     case 1:
                         if let stream = request.httpBodyStream {
@@ -1347,9 +1337,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": "2016-12-03T08:52:19.204Z"
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=2a37d253-752f-42cd-987e-db319a626077%2Fa2f88ffc-e7fe-4d17-aa69-063088cb24fa&uploadType=resumable&predefinedAcl=publicRead&upload_id=AEnB2Uqwlm2GQ0JWMApi0ApeBHQ0PxjY3hSe_VNs5geuZFxLBkrwiI0gLldrE8GgkqX4ahWtRJ1MHombFq8hQc9o5772htAvDQ",
-                            "_expiresAt": "2016-12-10T08:52:19.488Z",
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": "2016-12-10T08:52:19.488Z"
                         ])
                     case 1:
                         if let stream = request.httpBodyStream {
@@ -1635,13 +1623,13 @@ class FileTestCase: StoreTestCase {
     func testDownloadAndResume() {
         signUp()
         
-        let file = MyFile()
+        let file = FileType()
         file.label = "trailer"
         file.publicAccessible = true
         self.file = file
         let path = caminandes3TrailerURL.path
         
-        let fileStore = FileStore<MyFile>()
+        let fileStore = FileStore<FileType>()
         
         do {
             if useMockData {
@@ -1664,9 +1652,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": Date().toISO8601()
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)/o?name=\(UUID().uuidString)%2F\(UUID().uuidString)&uploadType=resumable&predefinedAcl=publicRead&upload_id=\(UUID().uuidString)",
-                            "_expiresAt": Date().toISO8601(),
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": Date().toISO8601()
                         ])
                     case 1:
                         return HttpResponse(json: [
@@ -1789,9 +1775,13 @@ class FileTestCase: StoreTestCase {
             }
         }
         
+        guard self.myFile != nil else {
+            return
+        }
+
         do {
             weak var expectationDownload = expectation(description: "Download")
-            
+
             let request = fileStore.download(self.myFile!) { (file, data: Data?, error) in
                 self.myFile = file
                 XCTFail(error?.localizedDescription ?? "Handler was not expected to be called")
@@ -2317,9 +2307,7 @@ class FileTestCase: StoreTestCase {
                                 "ect": Date().toISO8601()
                             ],
                             "_uploadURL": "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)/o?name=\(UUID().uuidString)%2F\(UUID().uuidString)&uploadType=resumable&predefinedAcl=publicRead&upload_id=\(UUID().uuidString)",
-                            "_expiresAt": Date().toISO8601(),
-                            "_requiredHeaders": [
-                            ]
+                            "_expiresAt": Date().toISO8601()
                         ])
                     case 1:
                         return HttpResponse(json: [
@@ -2561,9 +2549,7 @@ class FileTestCase: StoreTestCase {
                                         "ect" : Date().toISO8601()
                                     ],
                                     "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/0b5b1cd673164e3185a2e75e815f5cfe/o?name=b69d8159-e59f-4337-b03b-1c2df3ccfed9%2F9b77d4f0-43ea-4d70-9f65-e40808d1e429&uploadType=resumable&upload_id=AEnB2Up1heH7qbZXQIqsaT-XJNJTv3OKufiMN_9OXh5qGPVfwP4SaWrU5LW7-ZXswXc11l_Wi027IUjZx44CzajfycP8aam7HQ",
-                                    "_expiresAt" : Date(timeIntervalSinceNow: 7 * TimeUnit.day.timeInterval).toISO8601(),
-                                    "_requiredHeaders" : [
-                                    ]
+                                    "_expiresAt" : Date(timeIntervalSinceNow: 7 * TimeUnit.day.timeInterval).toISO8601()
                                 ])
                             case 1:
                                 return HttpResponse(json: [
@@ -3131,9 +3117,7 @@ class FileTestCase: StoreTestCase {
                             "ect" : Date().toISO8601()
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
-                        "_expiresAt" : Date().toISO8601(),
-                        "_requiredHeaders" : [
-                        ]
+                        "_expiresAt" : Date().toISO8601()
                     ]
                 )
             default:
@@ -3211,9 +3195,7 @@ class FileTestCase: StoreTestCase {
                             "ect" : Date().toISO8601()
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
-                        "_expiresAt" : Date().toISO8601(),
-                        "_requiredHeaders" : [
-                        ]
+                        "_expiresAt" : Date().toISO8601()
                     ]
                 )
             default:
@@ -3290,7 +3272,8 @@ class FileTestCase: StoreTestCase {
                         ],
                         "_uploadURL" : "https://www.googleapis.com/upload/storage/v1/b/\(UUID().uuidString)",
                         "_expiresAt" : Date().toISO8601(),
-                        "_requiredHeaders" : [
+                        "_requiredHeaders": [
+                            "TEST_HEADER": "TEST_HEADER_VALUE"
                         ]
                     ]
                 )
@@ -3311,6 +3294,8 @@ class FileTestCase: StoreTestCase {
             XCTAssertNotNil(file.fileId)
             XCTAssertNotNil(file.uploadURL)
             XCTAssertFalse(file.publicAccessible)
+            XCTAssertNotNil(file.uploadHeaders)
+            XCTAssertEqual(file.uploadHeaders!["TEST_HEADER"], "TEST_HEADER_VALUE")
         }
     }
     
@@ -3334,5 +3319,12 @@ class FileTestCase: StoreTestCase {
             XCTAssertTimeoutError(error)
         }
     }
+}
+
+class MyFileTestCase : FileTestCase<MyFile> {
+    
+}
+
+class MyFileCodableTestCase : FileTestCase<MyFileCodable> {
     
 }

--- a/Kinvey/KinveyTests/FileTestCase.swift
+++ b/Kinvey/KinveyTests/FileTestCase.swift
@@ -3328,3 +3328,29 @@ class MyFileTestCase : FileTestCase<MyFile> {
 class MyFileCodableTestCase : FileTestCase<MyFileCodable> {
     
 }
+
+class MyFileTestCaseRunner: XCTestCase {
+    override func run() {
+        let suite = XCTestSuite(forTestCaseClass: MyFileTestCase.self)
+        suite.run()
+        super.run()
+    }
+
+    // At least one func is needed for `run` to be called
+    func testDummy() {
+        XCTAssert(true)
+    }
+}
+
+class MyFileCodableTestCaseRunner: XCTestCase {
+    override func run() {
+        let suite = XCTestSuite(forTestCaseClass: MyFileCodableTestCase.self)
+        suite.run()
+        super.run()
+    }
+
+    // At least one func is needed for `run` to be called
+    func testDummy() {
+        XCTAssert(true)
+    }
+}

--- a/Kinvey/KinveyTests/MyFile.swift
+++ b/Kinvey/KinveyTests/MyFile.swift
@@ -9,19 +9,55 @@
 import Foundation
 import Kinvey
 
-class MyFile: File {
-    
+@objc protocol MyFileProtocol {
     @objc
-    dynamic var label: String?
-    
-    public convenience required init?(map: Map) {
-        self.init()
+    dynamic var label: String? { get set }
+}
+
+class MyFile: File, MyFileProtocol {
+
+    enum MyCodingKeys: String, CodingKey {
+        case label
     }
-    
+
+    var label: String?
+
     override func mapping(map: Map) {
         super.mapping(map: map)
-        
+
         label <- ("label", map["label"])
     }
+
+}
+
+class MyFileCodable : File, MyFileProtocol, Codable {
+    var label: String?
     
+    enum MyCodingKeys: String, CodingKey {
+        case label
+    }
+
+    public required init() {
+        super.init()
+    }
+
+    required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+
+    required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+
+    public required override init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: MyCodingKeys.self)
+        label = try container.decodeIfPresent(String.self, forKey: .label)
+        try super.init(from: decoder)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: MyCodingKeys.self)
+        try container.encodeIfPresent(label, forKey: .label)
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DEVCENTER_GIT=git@github.com:Kinvey/devcenter.git
 DEVCENTER_GIT_TEST=https://git.heroku.com/v3yk1n-devcenter.git
 DEVCENTER_GIT_PROD=https://git.heroku.com/kinvey-devcenter-prod.git
 CARTFILE_RESOLVED_MD5=$(shell { cat Cartfile.resolved; swift --version | sed -e "s/Apple //" | head -1 | awk '{ print "Swift " $$3 }'; } | tr "\n" "\n" | md5)
-DESTINATION_OS?=13.0
+DESTINATION_OS?=13.3
 DESTINATION_NAME?=iPhone 11 Pro
 ECHO?=no
 
@@ -22,7 +22,7 @@ clean:
 
 echo:
 	@echo $(ECHO)
-	
+
 checkout-dependencies:
 	carthage checkout
 
@@ -38,7 +38,7 @@ build-dependencies-ios: checkout-dependencies
 
 cartfile-md5:
 	@echo $(CARTFILE_RESOLVED_MD5)
-	
+
 cache:
 	test -s Carthage/$(CARTFILE_RESOLVED_MD5).tar.lzma || \
 	{ \
@@ -75,7 +75,7 @@ archive-ios:
 
 test: test-ios test-macos
 
-	
+
 test-ios:
 	xcodebuild -workspace Kinvey.xcworkspace -scheme Kinvey -destination 'OS=$(DESTINATION_OS),name=$(DESTINATION_NAME)' test -enableCodeCoverage YES
 
@@ -99,7 +99,7 @@ docs:
 				--xcodebuild-arguments -workspace,Kinvey.xcworkspace,-scheme,Kinvey \
 				--module Kinvey \
 				--output docs
-				
+
 deploy-cocoapods:
 	pod trunk push Kinvey.podspec
 
@@ -158,21 +158,21 @@ show-version:
 	@/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${PWD}/Kinvey/Kinvey/Info.plist" | xargs echo 'Info.plist    '
 	@cat Kinvey.podspec | grep "s.version\s*=\s*\"[0-9]*.[0-9]*.[0-9]*\"" | awk {'print $$3'} | sed 's/"//g' | xargs echo 'Kinvey.podspec'
 	@agvtool what-version | awk '0 == NR % 2' | awk {'print $1'} | xargs echo 'Project Version  '
-	
+
 set-version:
 	@echo 'Current Version:'
 	@echo '----------------------'
 	@$(MAKE) show-version
-	
+
 	@echo
-	
+
 	@echo 'New Version:'
 	@read version; \
 	\
 	/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $$version" "${PWD}/Kinvey/Kinvey/Info.plist"; \
 	sed -i -e "s/s.version[ ]*=[ ]*\"[0-9]*.[0-9]*.[0-9]*\"/s.version      = \"$$version\"/g" Kinvey.podspec; \
 	rm Kinvey.podspec-e
-	
+
 	@echo
 	@echo
 


### PR DESCRIPTION

#### Description
Fixes issue [Custom properties of class inherited from `File` and adopting `Codable` protocol are not sent to the backend](https://kinvey.atlassian.net/projects/MLIBZ/issues/MLIBZ-3195)

Steps to reproduce:
1. Create a subclass of Kinvey `File`
2. Add some custom property
3. Implement `Codable` protocol adoption
4. Try to upload a file using this custom class

**Actual Result**:
Method `encode(to encoder: Encoder)` is not called. Any custom properties from the class are not sent to Kinvey.

**Expected Result**:
Custom properties are sent to Kinvey along with default `File` class properties.

#### Changes
* Make `File` conform to `JSONCodable` protocol
* Add implementations for `encode(to)` and `init(from)`
* Copy `EntityCodingKeys` values to `FileCodingKeys`
because `Codable` implementation methods must use
values from one enum only and (afaik) enums cannot
have their values assigned from other enums

* Use `parseObject` which works with both `Mappable`
and `Codable` instead of `parseDictionary` in `FileStore`

* Use `jsonParser.toJSON` instead of `file.toJSON()` which
automatically handles both cases as well

#### Tests
* Remove empty `_requiredHeaders` from test cases
because it's treated as an empty array when deserialized
with `Decoder` in `init(from)`. And add a `TEST_HEADER`
header in one test scenario (`testCreateBucketInputStream`)

* Add test cases for both `Encodable` and the deprecated
`Mappable` serialization approaches by making `FileTestCase`
a generic base class and inheriting it with 2 concrete Test
classes

