### PR TITLE
fix:  Carthage build uses cache and no binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ after_failure:
 - echo System Log
 - tail -n 1000 /var/log/system.log
 - echo Simulator Logs
-- cat  ~/Library/Logs/CoreSimulator/*/system.log"
+- cat  ~/Library/Logs/CoreSimulator/*/system.log
 - echo Xcode Crash Logs
 - find ~/Library/Developer/Xcode/DerivedData/ -iname *.crash -exec echo "*****" \; -print -exec cat {} \;
 after_success:

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -1021,7 +1021,7 @@ open class DataStore<T: Persistable> where T: NSObject {
             deltaSet: deltaSet
         ) { (result: Swift.Result<(UInt, [T]), MultipleErrors>) in
             switch result {
-            case .success(let count, let array):
+            case .success((let count, let array)):
                 completionHandler?(count, array, nil)
             case .failure(let errors):
                 completionHandler?(nil, nil, errors.errors)
@@ -1048,7 +1048,7 @@ open class DataStore<T: Persistable> where T: NSObject {
             }
             
             switch result {
-            case .success(let count, let results):
+            case .success((let count, let results)):
                 completionHandler(.success((count, Array(results))))
             case .failure(let error):
                 completionHandler(.failure(error))
@@ -1057,7 +1057,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         return AnyRequest(request) {
             if let result = $0 {
                 switch result {
-                case .success(let count, let results):
+                case .success((let count, let results)):
                     return .success((count, Array(results)))
                 case .failure(let error):
                     return .failure(error)

--- a/Kinvey/Kinvey/Result.swift
+++ b/Kinvey/Kinvey/Result.swift
@@ -63,7 +63,7 @@ extension Swift.Result {
             return
         }
         switch self {
-        case .success(let arg1, let arg2):
+        case .success((let arg1, let arg2)):
             completionHandler(arg1, arg2, nil)
         case .failure(let failure):
             completionHandler(nil, nil, failure)


### PR DESCRIPTION
#### Description
Before this fix building all the platforms with `make build` failed because of the missing platforms in the PubNub downloaded binary.

#### Changes
* Add command-line options to Carthage build:
    * `--cache-builds` greatly improves build times, especially when
    diagnosing issues with any of the dependencies. Issue a warning to
    clean the workspace if producing a release build.
    * `--no-use-binaries` builds every dependency from source instead of
    downloading it from the GitHub release. This ensures
    correct binaries because it's possible that some of the
    downloaded ones do not contain all platforms that we support
    (e.g. PubNub v4.13.1 is missing tvOS and watchOS)

* Fix tuple warnings
