### PR TITLE
fix: Consistent MultiSaveError behavior

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey-macOS.xcscheme
+++ b/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey-macOS.xcscheme
@@ -71,9 +71,6 @@
                <Test
                   Identifier = "PerformanceTestCase">
                </Test>
-               <Test
-                  Identifier = "SyncStoreTestApi4">
-               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference

--- a/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey.xcscheme
+++ b/Kinvey/Kinvey.xcodeproj/xcshareddata/xcschemes/Kinvey.xcscheme
@@ -52,6 +52,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
+            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
@@ -69,9 +70,6 @@
                </Test>
                <Test
                   Identifier = "PerformanceTestCase">
-               </Test>
-               <Test
-                  Identifier = "SyncStoreTestApi4">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -344,19 +344,19 @@ extension NSException {
 public struct MultiSaveError: Swift.Error, Codable, IndexableError {
     
     public let index: Int
-    public let message: String
+    public let error: String
     public let serverDescription: String?
     public let serverDebug: String?
 
     enum CodingKeys: String, CodingKey {
         case index
-        case message = "error"
+        case error
         case serverDescription = "description"
         case serverDebug = "debug"
     }
     
     public var localizedDescription: String {
-        return message
+        return self.serverDescription != nil ? self.serverDescription! : error
     }
     
 }
@@ -364,19 +364,19 @@ public struct MultiSaveError: Swift.Error, Codable, IndexableError {
 extension MultiSaveError: LocalizedError {
     
     public var errorDescription: String? {
-        return message
+        return localizedDescription
     }
     
     public var failureReason: String? {
-        return message
+        return localizedDescription
     }
     
     public var recoverySuggestion: String? {
-        return message
+        return localizedDescription
     }
     
     public var helpAnchor: String? {
-        return message
+        return localizedDescription
     }
     
 }
@@ -384,7 +384,7 @@ extension MultiSaveError: LocalizedError {
 extension MultiSaveError: CustomStringConvertible {
     
     public var description: String {
-        return message
+        return localizedDescription
     }
     
 }
@@ -392,7 +392,7 @@ extension MultiSaveError: CustomStringConvertible {
 extension MultiSaveError: CustomDebugStringConvertible {
     
     public var debugDescription: String {
-        return message
+        return localizedDescription
     }
     
 }

--- a/Kinvey/Kinvey/PushOperation.swift
+++ b/Kinvey/Kinvey/PushOperation.swift
@@ -165,14 +165,14 @@ internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, MultipleErr
                                     }))
                                     entitiesErrors = AnyRandomAccessCollection(errorsJson.lazy.compactMap({ (error) -> MultiSaveError? in
                                         guard let index = error[MultiSaveError.CodingKeys.index.rawValue] as? Int,
-                                            let message = error[MultiSaveError.CodingKeys.message.rawValue] as? String
+                                            let message = error[MultiSaveError.CodingKeys.error.rawValue] as? String
                                         else {
                                             return nil
                                         }
                                         let description = error[MultiSaveError.CodingKeys.serverDescription.rawValue] as? String
                                         let debug = error[MultiSaveError.CodingKeys.serverDebug.rawValue] as? String
                                         
-                                        return MultiSaveError(index: index, message: message, serverDescription: description, serverDebug: debug)
+                                        return MultiSaveError(index: index, error: message, serverDescription: description, serverDebug: debug)
                                     }))
                                     let objectIdsToBeRemoved = zip(objectIds, objectIdsRemoved).compactMap { objectId, removed in
                                         return removed ? objectId : nil

--- a/Kinvey/Kinvey/SaveMultiOperation.swift
+++ b/Kinvey/Kinvey/SaveMultiOperation.swift
@@ -259,7 +259,7 @@ internal class SaveMultiOperation<T: Persistable>: WriteOperation<T, MultiSaveRe
                         
                         return MultiSaveError(
                             index: index,
-                            message: error,
+                            error: error,
                             serverDescription: description,
                             serverDebug: debug
                         )
@@ -299,7 +299,7 @@ internal class SaveMultiOperation<T: Persistable>: WriteOperation<T, MultiSaveRe
                         case let multiSaveError as MultiSaveError:
                             return MultiSaveError(
                                 index: entitiesCount + multiSaveError.index,
-                                message: multiSaveError.message,
+                                error: multiSaveError.error,
                                 serverDescription: multiSaveError.serverDescription,
                                 serverDebug: multiSaveError.serverDebug
                             )

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -24,10 +24,12 @@ extension XCTestCase {
         }
 
         CFRunLoopAddObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
+        if !evaluate() {
         CFRunLoopRunInMode(.defaultMode, timeout, false)
+        }
         CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
 
-        return result
+        return result || evaluate()
     }
 
 }

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -25,7 +25,7 @@ extension XCTestCase {
 
         CFRunLoopAddObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
         if !evaluate() {
-        CFRunLoopRunInMode(.defaultMode, timeout, false)
+            CFRunLoopRunInMode(.defaultMode, timeout, false)
         }
         CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
 

--- a/Kinvey/KinveyTests/MultiInsertSpec.swift
+++ b/Kinvey/KinveyTests/MultiInsertSpec.swift
@@ -356,11 +356,11 @@ class MultiInsertSpec: QuickSpec {
                                 return
                             }
                             expect(firstError.index).to(equal(0))
-                            expect(firstError.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
+                            expect(firstError.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
                             expect(firstError.serverDescription).to(equal("description"))
                             expect(firstError.serverDebug).to(equal("debug"))
                             expect(lastError.index).to(equal(1))
-                            expect(lastError.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id2)\" }"))
+                            expect(lastError.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id2)\" }"))
                             expect(lastError.serverDescription).to(equal("description"))
                             expect(lastError.serverDebug).to(equal("debug"))
                         }
@@ -428,7 +428,7 @@ class MultiInsertSpec: QuickSpec {
                                 return
                             }
                             expect(firstError.index).to(equal(0))
-                            expect(firstError.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
+                            expect(firstError.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
                             expect(firstError.serverDescription).to(equal("description"))
                             expect(firstError.serverDebug).to(equal("debug"))
                         }
@@ -496,7 +496,7 @@ class MultiInsertSpec: QuickSpec {
                                 return
                             }
                             expect(firstError.index).to(equal(1))
-                            expect(firstError.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
+                            expect(firstError.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
                             expect(firstError.serverDescription).to(equal("description"))
                             expect(firstError.serverDebug).to(equal("debug"))
                         }
@@ -1078,7 +1078,7 @@ class MultiInsertSpec: QuickSpec {
                     
                     expect(multiSaveError?.index).to(equal(1))
                     
-                    expect(multiSaveError?.message).to(equal(errorMessage))
+                    expect(multiSaveError?.error).to(equal(errorMessage))
                     
                     expect(syncDataStore.pendingSyncCount()).to(equal(1))
                     expect(syncDataStore.pendingSyncEntities().count).to(equal(1))
@@ -1351,13 +1351,13 @@ class MultiInsertSpec: QuickSpec {
                         
                         let firstError = result?.errors.first as? MultiSaveError
                         expect(firstError?.index).to(equal(0))
-                        expect(firstError?.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
+                        expect(firstError?.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id1)\" }"))
                         expect(firstError?.serverDescription).to(equal("description"))
                         expect(firstError?.serverDebug).to(equal("debug"))
 
                         let lastError = result?.errors.last as? MultiSaveError
                         expect(lastError?.index).to(equal(1))
-                        expect(lastError?.message).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id2)\" }"))
+                        expect(lastError?.error).to(equal("E11000 duplicate key error collection: kdb1.kid1.Person index: _id_ dup key: { : \"\(id2)\" }"))
                         expect(lastError?.serverDescription).to(equal("description"))
                         expect(lastError?.serverDebug).to(equal("debug"))
 

--- a/Kinvey/KinveyTests/NetworkStoreTests.swift
+++ b/Kinvey/KinveyTests/NetworkStoreTests.swift
@@ -347,7 +347,7 @@ class NetworkStoreTests: StoreTestCase {
                 XCTAssertNotNil(error)
                 if let error = error {
                     XCTAssertEqual(error.index, 1)
-                    XCTAssertEqual(error.message, "E11000 duplicate key error index: kdb1923.\(self.client.appKey!).Person.$_id_ dup key: { : \"\(id)\" }")
+                    XCTAssertEqual(error.error, "E11000 duplicate key error index: kdb1923.\(self.client.appKey!).Person.$_id_ dup key: { : \"\(id)\" }")
                     XCTAssertEqual(error.serverDescription, "description")
                     XCTAssertEqual(error.serverDebug, "debug")
                 }


### PR DESCRIPTION
#### Description
#### Changes
* Consistent `MultiSaveError` behavior
  * Rename `message` to `error` to match the property
name in the SDKs for other languages
  * `localizedDescription` returns `description` as it was with v4
of the API
  * Implement all methods from the `LocalizedError` protocol
with `localizedDescription`

#### Tests
* Reenable parallel execution and `SyncStoreTestApi4` test class in 
`Kinvey` and `Kinvey-macOS` schemes. These were disabled in an effort 
to fix  sporadical failures which later turned out to be caused by missing 
`realm.refresh` calls.

* Double check evaluation handler in `wait(toBeTrue:)`
It is possible for the condition to not be evaluated even once if
all async actions have been completed prior to entering
`CFRunLoopRunInMode`. This fixes sporadic failures of some of the tests
on Travis CI

refs: https://kinvey.atlassian.net/browse/KDEV-859?focusedCommentId=67851