### PR TITLE
KDEV-1151: Respect maximum items per request limit on push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Kinvey.framework.zip
 scripts/RealtimeSend/Rome
 Package.resolved
 Kinvey.xcodeproj
+.swiftpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ before_script:
 # Workaround for error `Segmentation fault: 11` during `carthage checkout`
 # downgrade carthage 0.34.0 to 0.33.0 (see issue and comment here: https://github.com/Carthage/Carthage/issues/2760#issuecomment-551499537)
 - if carthage version | grep 0.34.0; then
-    brew uninstall carthage;
-    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d453dd956dbfc5b724b0fdaeb14f9480f461479d/Formula/carthage.rb;
+    brew upgrade carthage;
   fi
 - xcpretty --version
 - if [ ! -d $( md5 Cartfile.resolved | awk '{ print "Carthage/" $4 ".zip" }' ) ]; then

--- a/Kinvey/Kinvey/SaveMultiOperation.swift
+++ b/Kinvey/Kinvey/SaveMultiOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import PromiseKit
 
-private let maxSizePerRequest = 100
+internal let maxSizePerRequest = 100
 
 public typealias MultiSaveResultTuple<T> = (entities: AnyRandomAccessCollection<T?>, errors: AnyRandomAccessCollection<Swift.Error>)
 


### PR DESCRIPTION
#### Description
When the number of entities in a `save()` or `push()` request exceeds the max allowed in the request (100 entities), the entities should be broken down into multiple sets of the max amount allowed, and multiple multi-insert requests should be sent out. `push()` however didn't follow this logic.

refs https://kinvey.atlassian.net/browse/KDEV-1151

#### Changes
* Split into multiple `pendingOperations` when items to
sync are more than `maxSizePerRequest` (100)
* Remove `;` which are reported as linter warnings
* Add `.swiftpm` to `.gitignore`

#### Tests
* Test with the sample provided in the Jira item
* Add a test case for push with a number of items which is
1,1 times greater than the limit
