### PR TITLE
release: v6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,23 @@
-
 name: CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron:  '0 7 * * *'
+    - cron: "0 7 * * *"
   workflow_dispatch: ~
 
 jobs:
   swift-build:
     runs-on: macos-11
     steps:
-      - run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         id: spm-cache-key
         with:
           path: README.md
-          key: key-${{ runner.os }}-spm-13.0-${{ hashFiles('**/Package.swift') }}
+          key: key-${{ runner.os }}-spm-13.2.1-${{ hashFiles('**/Package.swift') }}
 
       - if: steps.spm-cache-key.outputs.cache-hit != 'true'
         run: swift build
@@ -26,26 +25,26 @@ jobs:
   build-deps:
     runs-on: macos-11
     steps:
-      - run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         id: carthage-cache-key
         with:
           path: README.md
-          key: key-${{ runner.os }}-carthage-13.0-${{ hashFiles('**/Cartfile.resolved') }}
+          key: key-${{ runner.os }}-carthage-13.2.1-${{ hashFiles('**/Cartfile.resolved') }}
 
       - if: steps.carthage-cache-key.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         id: carthage-cache
         with:
           path: Carthage
-          key: ${{ runner.os }}-carthage-13.0-${{ hashFiles('**/Cartfile.resolved') }}
+          key: ${{ runner.os }}-carthage-13.2.1-${{ hashFiles('**/Cartfile.resolved') }}
 
       - if: steps.carthage-cache-key.outputs.cache-hit != 'true'
         run: make build-deps
 
   test-ios:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - uses: actions/checkout@v2
@@ -63,13 +62,13 @@ jobs:
     needs: build-deps
     runs-on: macos-11
     steps:
-      - run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         id: carthage-cache
         with:
           path: Carthage
-          key: ${{ runner.os }}-carthage-13.0-${{ hashFiles('**/Cartfile.resolved') }}
+          key: ${{ runner.os }}-carthage-13.2.1-${{ hashFiles('**/Cartfile.resolved') }}
 
       - if: steps.carthage-cache.outputs.cache-hit == 'true'
         run: make test-macos

--- a/Kinvey.podspec
+++ b/Kinvey.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Kinvey"
-  s.version      = "6.0.0-rc.1"
+  s.version      = "6.0.0"
   s.summary      = "Kinvey Swift SDK"
 
   # This description is used to generate tags and improve search results.

--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -4580,7 +4580,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
@@ -4641,7 +4640,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;

--- a/Kinvey/Kinvey/Info.plist
+++ b/Kinvey/Kinvey/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.0-rc.1</string>
+	<string>6.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "Kinvey",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v10),
-        .tvOS(.v10),
+        .iOS(.v12),
+        .tvOS(.v12),
         .watchOS(.v3)
     ],
     products: [


### PR DESCRIPTION
Additional Changes:
* Fix Package.swift for SPM was not targeting minimum iOS 12
* Update CI workflow Xcode version to 13.2.1 for all tests